### PR TITLE
Fix a crash when creating folders on mobile

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -40,10 +40,11 @@ export class RemindersController {
     );
   }
 
-  async removeFile(path: string) {
+  async removeFile(path: string): Promise<boolean> {
     console.debug("Remove file: path=%s", path);
-    this.reminders.removeFile(path);
+    const result = this.reminders.removeFile(path);
     this.reloadUI();
+    return result;
   }
 
   async reloadFile(file: TAbstractFile, reloadUI: boolean = false) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,14 +62,16 @@ export default class ReminderPlugin extends Plugin {
   }
 
   override async onload() {
-    await this.pluginDataIO.load();
-    if (this.pluginDataIO.debug.value) {
-      monkeyPatchConsole(this);
-    }
     this.setupUI();
     this.setupCommands();
-    this.watchVault();
-    this.startPeriodicTask();
+    this.app.workspace.onLayoutReady(async () => {
+      await this.pluginDataIO.load();
+      if (this.pluginDataIO.debug.value) {
+        monkeyPatchConsole(this);
+      }
+      this.watchVault();
+      this.startPeriodicTask();
+    })
   }
 
   private setupUI() {
@@ -106,14 +108,11 @@ export default class ReminderPlugin extends Plugin {
       });
     }
 
-    // Open reminder list view
-    if (this.app.workspace.layoutReady) {
+    // Open reminder list view. This callback will fire immediately if the
+    // layout is ready, and will otherwise be enqueued.
+    this.app.workspace.onLayoutReady(() => {
       this.viewProxy.openView();
-    } else {
-      (this.app.workspace as any).on("layout-ready", () => {
-        this.viewProxy.openView();
-      });
-    }
+    });
   }
 
   private setupCommands() {
@@ -203,9 +202,13 @@ export default class ReminderPlugin extends Plugin {
       this.app.vault.on("delete", (file) => {
         this.remindersController.removeFile(file.path);
       }),
-      this.app.vault.on("rename", (file, oldPath) => {
-        this.remindersController.removeFile(oldPath);
-        this.remindersController.reloadFile(file);
+      this.app.vault.on("rename", async (file, oldPath) => {
+        // We only reload the file if it CAN be deleted, otherwise this can
+        // cause crashes.
+        if (await this.remindersController.removeFile(oldPath)) {
+          // We need to do the reload synchronously so as to avoid racing.
+          await this.remindersController.reloadFile(file);
+        }
       }),
     ].forEach(eventRef => {
       this.registerEvent(eventRef);
@@ -214,6 +217,8 @@ export default class ReminderPlugin extends Plugin {
 
   private startPeriodicTask() {
     let intervalTaskRunning = false;
+    // Force the view to refresh as soon as possible.
+    this.periodicTask();
     this.registerInterval(
       window.setInterval(() => {
         if (intervalTaskRunning) {
@@ -249,10 +254,12 @@ export default class ReminderPlugin extends Plugin {
       SETTINGS.reminderTime.value
     );
     expired.forEach((reminder) => {
-      if (reminder.muteNotification) {
-        return;
+      if (this.app.workspace.layoutReady) {
+        if (reminder.muteNotification) {
+          return;
+        }
+        this.showReminder(reminder);
       }
-      this.showReminder(reminder);
     });
   }
 

--- a/src/model/reminder.ts
+++ b/src/model/reminder.ts
@@ -6,6 +6,15 @@ export class Reminder {
   // To avoid duplicate notification, set this flag true before notification and set false on notification done.
   public muteNotification: boolean = false;
 
+  /* Given that `muteNotification` above is playing double duty, we need a flag
+   * that lets us serialize reminder display to prevent overload problems on
+   * mobile.
+   *
+   * It should be set to `true` before the reminder is displayed, and then set
+   * to false once the reminder is dealt with.
+   */
+  public beingDisplayed: boolean = false;
+
   constructor(
     public file: string,
     public title: string,

--- a/src/ui/reminder.ts
+++ b/src/ui/reminder.ts
@@ -97,6 +97,10 @@ class NotificationModal extends Modal {
   }
 
   override onOpen() {
+    // When the modal is opened we mark the reminder as being displayed. This
+    // lets us introspect the reminder's display state from elsewhere.
+    this.reminder.beingDisplayed = true;
+
     let { contentEl } = this;
     new ReminderView({
       target: contentEl,
@@ -128,6 +132,9 @@ class NotificationModal extends Modal {
   }
 
   override onClose() {
+    // Unset the reminder from being displayed. This lets other parts of the
+    // plugin continue.
+    this.reminder.beingDisplayed = false;
     let { contentEl } = this;
     contentEl.empty();
     if (this.canceled) {


### PR DESCRIPTION
This PR also ensures that the reminders controller waits for view initialisation before processing files and discovering reminders. This ensures that it can't cause Obsidian to crash and get into a reload loop.

Closes #59 