### PR TITLE
Feature #113 Support for task plugin scheduled date

### DIFF
--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -14,7 +14,7 @@ export class TasksPluginReminderModel implements ReminderModel {
     private static readonly symbolDueDate = Symbol.ofChars([..."📅📆🗓"]);
     private static readonly symbolDoneDate = Symbol.ofChar("✅");
     private static readonly symbolRecurrence = Symbol.ofChar("🔁");
-    private static readonly symbolReminder = Symbol.ofChar("⏰");
+    private static readonly symbolReminder = Symbol.ofChar("⏳");
     private static readonly allSymbols = [
         TasksPluginReminderModel.symbolDueDate,
         TasksPluginReminderModel.symbolDoneDate,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -117,7 +117,7 @@ class Settings {
     this.useCustomEmojiForTasksPlugin = this.settings.newSettingBuilder()
       .key("useCustomEmojiForTasksPlugin")
       .name("Distinguish between reminder date and due date")
-      .desc("Use custom emoji ⏰ instead of 📅 and distinguish between reminder date/time and Tasks Plugin's due date.")
+      .desc("Use custom emoji ⏳ instead of 📅 and distinguish between reminder date/time and Tasks Plugin's due date.")
       .tag(TAG_RESCAN)
       .toggle(false)
       .onAnyValueChanged(context => {


### PR DESCRIPTION
"Tasks" plugin for Scheduled time uses ⏳ emoji. "Reminder" plugin have option "Distinguish between reminder date and due date" which in theory must take reminder date from "Tasks" Scheduled time. But, because in options used different emoji (⏰), this dont happen. I fix it

**Before Fix**
 
![image](https://user-images.githubusercontent.com/116349326/198623417-7d9c3bf2-c140-4ffe-8640-3b97bd123c8e.png)

**After Fix**

![image](https://user-images.githubusercontent.com/116349326/198624763-85db7981-e1d8-42b7-b637-3f1582ba59d6.png)
