### PR TITLE
feature/independent time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-reminder-plugin",
-  "version": "1.1.12",
+  "version": "1.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-reminder-plugin",
-      "version": "1.1.12",
+      "version": "1.1.15",
       "license": "MIT",
       "dependencies": {
         "rrule": "^2.6.8",

--- a/src/model/format/reminder-tasks-plugin.test.ts
+++ b/src/model/format/reminder-tasks-plugin.test.ts
@@ -107,6 +107,15 @@ describe('TasksPluginReminderLine', (): void => {
             expectedMarkdown: `- [ ] Task ⏰ 2021-10-05 11:00 🔁 every month on the 5th 📅 2021-10-05
 - [x] Task ⏰ 2021-09-05 11:00 🔁 every month on the 5th 📅 2021-09-12 ✅ 2021-09-13`
         });
+});
+    test('modify() - customemoji - time - every month with time', async () => {
+        await testModify({
+            now: "2021-09-13 09:10",
+            customEmoji: true,
+            inputMarkdown: `- [ ] Task ⌚ 11:00 🔁 every month on the 5th 📅 2021-09-12`,
+            expectedMarkdown: `- [ ] Task ⌚ 11:00 🔁 every month on the 5th 📅 2021-10-05
+- [x] Task ⌚ 11:00 🔁 every month on the 5th 📅 2021-09-12 ✅ 2021-09-13`
+        });
     });
 });
 

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -245,14 +245,16 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
         }
 
         const today = this.config.getParameter(ReminderFormatParameterKey.now).moment();
+        /*
         today.set("hour", dtStart.get("hour"));
         today.set("minute", dtStart.get("minute"));
         today.set("second", dtStart.get("second"));
         today.set("millisecond", dtStart.get("millisecond"));
+        
         if (today.isAfter(dtStart)) {
             dtStart = today;
         }
-
+        */
         // clone dtStart because dtStart will be modified by utc() call.
         const base = dtStart.clone();
 
@@ -261,7 +263,7 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
             .utc(true)
             .toDate();
         const rrule = new RRule(rruleOptions);
-        const rdate = rrule.after(dtStart.toDate(), false);
+        const rdate = rrule.after(today.toDate(), false);
         
         // apply rrule to `base`
         const diff = rdate.getTime() - rruleOptions.dtstart.getTime()


### PR DESCRIPTION
Allows you to specify a time with the "watch" ⌚ emoji if the setting to differentiate between tasks and reminder emoji is turned on eg;

```markdown
- [ ] Task ⌚ 10:00 📅 2021-09-17
```
I'm by no means a professional and not very familiar with the codebase, so this isn't very well implemented. I basically just forked this for personal use, but figured maybe you might want to pull it in, its just some nice QOL to make tasks a bit shorter and easier to use with the tasks plugin.

All the tests pass (on linux), I added a single test for the added feature, and I added info on how to use it (as well as the bug I've encountered with recurrence) into the docs.