### PR TITLE
Change `Todo.regexp` to accept more than one space before [

### DIFF
--- a/src/model/format/markdown.test.ts
+++ b/src/model/format/markdown.test.ts
@@ -8,6 +8,7 @@ describe('MarkdownDocument', (): void => {
 - [ ] Task2
   * [x] Task2-1
   - [ ]   Task2-2
+  -  [ ]   Task2-3
 > - [ ] Task in call out
 >> - [ ] Task in nested call out
 > > - [ ] Task in nested call out2`;
@@ -20,9 +21,10 @@ describe('MarkdownDocument', (): void => {
         new Todo(3, '- [', " ", '] ', 'Task2'),
         new Todo(4, '  * [', "x", '] ', 'Task2-1'),
         new Todo(5, '  - [', " ", ']   ', 'Task2-2'),
-        new Todo(6, '> - [', " ", '] ', 'Task in call out'),
-        new Todo(7, '>> - [', " ", '] ', 'Task in nested call out'),
-        new Todo(8, '> > - [', " ", '] ', 'Task in nested call out2')
+        new Todo(6, '  -  [', " ", ']   ', 'Task2-3'),
+        new Todo(7, '> - [', " ", '] ', 'Task in call out'),
+        new Todo(8, '>> - [', " ", '] ', 'Task in nested call out'),
+        new Todo(9, '> > - [', " ", '] ', 'Task in nested call out2')
       ]);
 
     todos[0]!.body = "New Task1 ";
@@ -33,6 +35,7 @@ describe('MarkdownDocument', (): void => {
 - [ ] Task2
   * [x] Task2-1
   - [ ]   Task2-2
+  -  [ ]   Task2-3
 > - [ ] Task in call out
 >> - [ ] Task in nested call out
 > > - [ ] Task in nested call out2`);
@@ -47,6 +50,7 @@ describe('MarkdownDocument', (): void => {
 - [ ] Task2
   * [x] Task2-1
   - [ ]   Task2-2
+  -  [ ]   Task2-3
 > - [ ] Task in call out
 >> - [ ] Task in nested call out
 > > - [ ] Task in nested call out2`);

--- a/src/model/format/markdown.ts
+++ b/src/model/format/markdown.ts
@@ -9,7 +9,7 @@ export class Todo {
     // check: 'x'
     // suffix: '] '
     // body: hello
-    private static readonly regexp = /^(?<prefix>((> ?)*)?\s*[\-\*] \[)(?<check>.)(?<suffix>\]\s+)(?<body>.*)$/;
+    private static readonly regexp = /^(?<prefix>((> ?)*)?\s*[\-\*][ ]+\[)(?<check>.)(?<suffix>\]\s+)(?<body>.*)$/;
 
     static parse(lineIndex: number, line: string): Todo | null {
         const match = Todo.regexp.exec(line);


### PR DESCRIPTION
I've found issue which appears to have same effects as issue #51 . I think some plugins may insert extra space before `[` during lists edit. Making regexp less restrictive solves problem for me at least