### PR TITLE
Updated typo and included Grammarly suggestions

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -15,7 +15,7 @@ Built-in notification looks like the following:
 When you click the file name(in the above example, `TODO.md`), the reminder will be [muted](#mute-notification) once, and the file will be opened.
 
 :::tip
-Muted reminders will be in reminder list's [Overdue section](/guide/list-reminders.html#overdue-reminders).
+Muted reminders will be in the reminder list's [Overdue section](/guide/list-reminders.html#overdue-reminders).
 :::
 
 If you click `Mark as Done`, your reminder TODO item will be checked and it will not be shown in the future.
@@ -26,18 +26,18 @@ If you click `Remind Me Later`, you can choose how long you want to postpone the
 
 The date and time in the markdown will be updated according to your choice.
 
-`Remind Me Later`'s option are customizable with [Remind Me Later](/setting/#remind-me-later) setting.
+The `Remind Me Later`'s option is customizable with [Remind Me Later](/setting/#remind-me-later) setting.
 
 ## System notification
 
-Instead of builtin notification, system notification is also available by [setting](/setting/#use-system-notification).
+Instead of built-in notification, a system notification is also available by [setting](/setting/#use-system-notification).
 
 <img :src="$withBase('/images/notification-mac.png')" width="400px">
 
-- If you click the notification, builtin notificaiton will be displayed in Obsidian app.
+- If you click the notification, the built-in notification will be displayed in the Obsidian app.
 - If you close the notification, the reminder is [muted](#mute-notification)
 
-Also, if you are using macOS, you can mark as done or postpone the reminder with the notification options.
+Also, if you are using macOS, you can mark it as done or postpone the reminder with the notification options.
 
 ## Mute notification
 
@@ -45,9 +45,9 @@ The reminder will be muted if you do the following:
 
 - In builtin notification,
     - press <kbd>Esc</kbd>
-    - click out side of the notification modal
+    - click outside of the notification modal
 - Close the system notification
 
-Muted reminder will not be notified again until
-- you restart Obsidian app
+A muted reminder will not be notified again until
+- you restart the Obsidian app
 - you click muted reminder in [reminder list view](/guide/list-reminders.html)


### PR DESCRIPTION
First off, this is a great plugin. 

I was actually reading the docs and noticed there was a typo in it. So I wanted to update that. During the process of changing the typo, Grammarly _(which by default runs on every website)_ suggested some minor fixes.

This PR is just a copy refresh. Please have a look.