### PR TITLE
add option to delete reminder when done

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-reminder-plugin",
-  "version": "1.1.12",
+  "version": "1.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-reminder-plugin",
-      "version": "1.1.12",
+      "version": "1.1.15",
       "license": "MIT",
       "dependencies": {
         "rrule": "^2.6.8",
@@ -1592,34 +1592,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
-      "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.0",
-        "@typescript-eslint/types": "5.42.0",
-        "@typescript-eslint/typescript-estree": "5.42.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -5880,22 +5852,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -8546,19 +8502,6 @@
         }
       }
     },
-    "@typescript-eslint/parser": {
-      "version": "5.42.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.0.tgz",
-      "integrity": "sha512-Ixh9qrOTDRctFg3yIwrLkgf33AHyEIn6lhyf5cCfwwiGtkWhNpVKlEZApi3inGQR/barWnY7qY8FbGKBO7p3JA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@typescript-eslint/scope-manager": "5.42.0",
-        "@typescript-eslint/types": "5.42.0",
-        "@typescript-eslint/typescript-estree": "5.42.0",
-        "debug": "^4.3.4"
-      }
-    },
     "@typescript-eslint/scope-manager": {
       "version": "5.42.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.0.tgz",
@@ -8700,8 +8643,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -9488,8 +9430,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/esbuild-svelte/-/esbuild-svelte-0.7.1.tgz",
       "integrity": "sha512-83vRAJ2OmoKxmK+rLFZVmyv5bJ8ahsYQwJ2RGmNAlHBIHq4ENUwA/hiwA2+AohrWD1BgZnGPMj8DL3l0I0xkug==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -9684,8 +9625,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -10938,8 +10878,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.0.6",
@@ -11717,13 +11656,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
-      "peer": true
-    },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -12255,8 +12187,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/svelte-jester/-/svelte-jester-2.0.1.tgz",
       "integrity": "sha512-Q7EMKMMUL08G68rWIEFrA0xuF4x30cKO6yIa6d/+7s30+b0/Tw4V+Sx0P/GtfweIgi3Aa0xUw4fJESD1o2MQew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "svelte-preprocess": {
       "version": "4.7.4",
@@ -12637,8 +12568,7 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
       "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -130,6 +130,7 @@ export class RemindersController {
     const content = new Content(file.path, await this.vault.read(file));
     await content.updateReminder(reminder, {
       checked,
+      shouldDelete: SETTINGS.deleteReminderOnComplete ? checked : false,
       time: reminder.time
     });
     await this.vault.modify(file, content.getContent());

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -130,7 +130,9 @@ export class RemindersController {
     const content = new Content(file.path, await this.vault.read(file));
     await content.updateReminder(reminder, {
       checked,
-      shouldDelete: SETTINGS.deleteReminderOnComplete ? checked : false,
+      shouldDelete: SETTINGS.deleteReminderOnComplete 
+        ? checked && reminder.title?.includes(SETTINGS.deleteReminderToken.value || "#delete")
+        : false,
       time: reminder.time
     });
     await this.vault.modify(file, content.getContent());

--- a/src/model/content.ts
+++ b/src/model/content.ts
@@ -3,7 +3,8 @@ import type { Reminder } from "model/reminder";
 import type { Todo } from "./format/markdown";
 
 export type ReminderTodoEdit = ReminderEdit & {
-  checked?: boolean
+  checked?: boolean,
+  shouldDelete?: boolean,
 }
 
 export class Content {

--- a/src/model/format/markdown.ts
+++ b/src/model/format/markdown.ts
@@ -109,6 +109,16 @@ export class MarkdownDocument {
         return found;
     }
 
+    public removeTodo(lineIndex: number): Todo | null {
+        const found = this.todos.find(todo => todo.lineIndex === lineIndex);
+        if (found == null) {
+            return null;
+        }
+        this.todos = this.todos.filter(todo => todo.lineIndex !== lineIndex);
+        this.lines.splice(lineIndex, 1);
+        return found;
+    }
+
     private applyChanges() {
         // apply changes of TODO items to lines
         this.todos.forEach(todo => {

--- a/src/model/format/reminder-base.ts
+++ b/src/model/format/reminder-base.ts
@@ -7,7 +7,8 @@ import { Todo } from "./markdown";
 export type ReminderEdit = {
     time?: DateTime,
     rawTime?: string,
-    checked?: boolean
+    checked?: boolean,
+    shouldDelete?: boolean,
 }
 export type ReminderInsertion = {
     insertedLine: string,
@@ -140,6 +141,13 @@ export abstract class TodoBasedReminderFormat<E extends ReminderModel> implement
         }
         const parsed = this.parseValidReminder(todo);
         if (parsed === null) {
+            return false;
+        }
+
+        if (edit.shouldDelete) {
+            if (doc.removeTodo(reminder.rowNumber)) {
+              return true;
+            }
             return false;
         }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,7 @@ class Settings {
   editDetectionSec: SettingModel<number, number>;
   reminderCheckIntervalSec: SettingModel<number, number>;
   deleteReminderOnComplete: SettingModel<boolean, boolean>;
+  deleteReminderToken: SettingModel<string, string>;
 
   constructor() {
     const reminderFormatSettings = new ReminderFormatSettings(this.settings);
@@ -151,8 +152,15 @@ class Settings {
     this.deleteReminderOnComplete = this.settings.newSettingBuilder()
       .key("deleteReminderOnComplete")
       .name("Delete reminder when done")
-      .desc("Upon completing a task, delete the line that the reminder was on.")
+      .desc("Upon completing a task, delete the line that the reminder was on if it contains a specific symbol.")
       .toggle(false)
+      .build(new RawSerde());
+    this.deleteReminderToken = this.settings.newSettingBuilder()
+      .key("deleteReminderToken")
+      .name("Delete reminder token")
+      .desc("Symbol or keyword to indicate that a reminder should be deleted when the task is completed (defaults to #delete).")
+      .text("#delete")
+      .placeHolder("#delete")
       .build(new RawSerde());
 
     this.settings
@@ -195,6 +203,7 @@ class Settings {
         this.editDetectionSec,
         this.reminderCheckIntervalSec,
         this.deleteReminderOnComplete,
+        this.deleteReminderToken
       );
 
     const config = new ReminderFormatConfig();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ class Settings {
   linkDatesToDailyNotes: SettingModel<boolean, boolean>;
   editDetectionSec: SettingModel<number, number>;
   reminderCheckIntervalSec: SettingModel<number, number>;
+  deleteReminderOnComplete: SettingModel<boolean, boolean>;
 
   constructor() {
     const reminderFormatSettings = new ReminderFormatSettings(this.settings);
@@ -147,6 +148,12 @@ class Settings {
       .desc("Interval(in seconds) to periodically check whether or not you should be notified of reminders.  You will need to restart Obsidian for this setting to take effect.")
       .number(5)
       .build(new RawSerde());
+    this.deleteReminderOnComplete = this.settings.newSettingBuilder()
+      .key("deleteReminderOnComplete")
+      .name("Delete reminder when done")
+      .desc("Upon completing a task, delete the line that the reminder was on.")
+      .toggle(false)
+      .build(new RawSerde());
 
     this.settings
       .newGroup("Notification Settings")
@@ -186,7 +193,8 @@ class Settings {
       .newGroup("Advanced")
       .addSettings(
         this.editDetectionSec,
-        this.reminderCheckIntervalSec
+        this.reminderCheckIntervalSec,
+        this.deleteReminderOnComplete,
       );
 
     const config = new ReminderFormatConfig();


### PR DESCRIPTION
![image](https://github.com/uphy/obsidian-reminder/assets/17055832/eaa39b32-6a49-4673-96b1-c35a3a27cf63)
As the title says, adds a checkbox to the settings under the "Advanced" section and when enabled will remove the reminder line upon marking it as done if it contains a token `#delete` by default