### PR TITLE
Consider cancelled tasks as checked

### DIFF
--- a/src/model/format/markdown.test.ts
+++ b/src/model/format/markdown.test.ts
@@ -55,4 +55,27 @@ describe('MarkdownDocument', (): void => {
 >> - [ ] Task in nested call out
 > > - [ ] Task in nested call out2`);
   });
+
+  test('Cancelled tasks are considered as checked', (): void => {
+    const md = `# TODO
+
+- [ ] Undone Task
+- [x] Completed Task
+- [-] Cancelled Task
+`
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos)
+      .toStrictEqual([
+        new Todo(2, '- [', " ", '] ', 'Undone Task'),
+        new Todo(3, '- [', "x", '] ', 'Completed Task'),
+        new Todo(4, '- [', "-", '] ', 'Cancelled Task')
+      ]);
+
+    expect(todos[0]!.isChecked()).toBe(false);
+    expect(todos[1]!.isChecked()).toBe(true);
+    expect(todos[2]!.isChecked()).toBe(true);
+    
+  });
 })

--- a/src/model/format/markdown.ts
+++ b/src/model/format/markdown.ts
@@ -36,7 +36,7 @@ export class Todo {
     }
 
     public isChecked() {
-        return this.check === 'x';
+        return this.check === 'x' || this.check === '-';
     }
 
     public setChecked(checked: boolean) {

--- a/src/model/format/markdown.ts
+++ b/src/model/format/markdown.ts
@@ -10,6 +10,7 @@ export class Todo {
     // suffix: '] '
     // body: hello
     private static readonly regexp = /^(?<prefix>((> ?)*)?\s*[\-\*][ ]+\[)(?<check>.)(?<suffix>\]\s+)(?<body>.*)$/;
+    private static readonly checkedStatuses = ['x', '-'];
 
     static parse(lineIndex: number, line: string): Todo | null {
         const match = Todo.regexp.exec(line);
@@ -36,7 +37,7 @@ export class Todo {
     }
 
     public isChecked() {
-        return this.check === 'x' || this.check === '-';
+        return Todo.checkedStatuses.some(status => status === this.check);
     }
 
     public setChecked(checked: boolean) {


### PR DESCRIPTION
Fixes #84 (partially, only adds cancelled tasks and it is not customizable).

I tried making it customizable via settings, but I think I'm not following the convention on the different classes, so I think it's better to just ship this PR first and address customisation separately.