### PR TITLE
fix: 'view.reload is not a function' issue introduced in Obsidian 1.7.4

### DIFF
--- a/src/ui/reminder-list.ts
+++ b/src/ui/reminder-list.ts
@@ -121,7 +121,13 @@ export class ReminderListItemViewProxy {
   private getViews() {
     return this.workspace
       .getLeavesOfType(VIEW_TYPE_REMINDER_LIST)
-      .map(leaf => leaf.view as ReminderListItemView);
+      .map((leaf) => {
+        if (leaf && leaf.view instanceof ReminderListItemView) {
+          return leaf.view as ReminderListItemView;
+        }
+        return null;
+      })
+      .filter((view) => view != null);
   }
 
   invalidate() {


### PR DESCRIPTION
fixes #201 

The following issue will not be fixed with this PR:

```
app.js:1 Error: Plugin "obsidian-reminder-plugin" is not passing Component in renderMarkdown. This is needed to avoid memory leaks when embedded contents register global event handlers.
    at t.render (app.js:1:1525664)
    at t.renderMarkdown (app.js:1:1525445)
    at eval (plugin:obsidian-reminder-plugin:15229:39)
    at flush (plugin:obsidian-reminder-plugin:14593:9)
    at init (plugin:obsidian-reminder-plugin:14741:5)
    at new Reminder2 (plugin:obsidian-reminder-plugin:16375:5)
    at NotificationModal.onOpen (plugin:obsidian-reminder-plugin:16458:5)
    at e.open (app.js:1:1304660)
    at ReminderModal.showBuiltinReminder (plugin:obsidian-reminder-plugin:16432:113)
    at ReminderModal.show (plugin:obsidian-reminder-plugin:16398:12)
```