### PR TITLE
feat: support multiple statuses for tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-reminder-plugin",
-  "version": "1.1.12",
+  "version": "1.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-reminder-plugin",
-      "version": "1.1.12",
+      "version": "1.1.15",
       "license": "MIT",
       "dependencies": {
         "rrule": "^2.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-reminder-plugin",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Reminder plugin for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/src/data.ts
+++ b/src/data.ts
@@ -63,7 +63,7 @@ export class PluginDataIO {
                 d.title,
                 DateTime.parse(d.time),
                 d.rowNumber,
-                false
+                " "
               )
           )
         );

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { openDateTimeFormatChooser } from "ui/datetime-format-modal";
 import { buildCodeMirrorPlugin } from "ui/editor-extension";
 import { ReminderModal } from "ui/reminder";
 import { ReminderListItemViewProxy } from "ui/reminder-list";
+import { ReminderStatus } from "model/format/reminder-base";
 import { OkCancel, showOkCancelDialog } from "ui/util";
 import { VIEW_TYPE_REMINDER_LIST } from "./constants";
 
@@ -297,13 +298,13 @@ export default class ReminderPlugin extends Plugin {
         console.info("Remind me later: time=%o", time);
         reminder.time = time;
         reminder.muteNotification = false;
-        this.remindersController.updateReminder(reminder, false);
+        this.remindersController.updateReminder(reminder, ReminderStatus.Todo);
         this.pluginDataIO.save(true);
       },
       () => {
         console.info("done");
         reminder.muteNotification = false;
-        this.remindersController.updateReminder(reminder, true);
+        this.remindersController.updateReminder(reminder, ReminderStatus.Done);
         this.reminders.removeReminder(reminder);
         this.pluginDataIO.save(true);
       },

--- a/src/model/content.ts
+++ b/src/model/content.ts
@@ -1,9 +1,10 @@
 import { MarkdownDocument, modifyReminder, parseReminder, ReminderEdit } from "model/format";
 import type { Reminder } from "model/reminder";
+import { ReminderStatus } from "./format/reminder-base";
 import type { Todo } from "./format/markdown";
 
 export type ReminderTodoEdit = ReminderEdit & {
-  checked?: boolean
+  status?: ReminderStatus;
 }
 
 export class Content {
@@ -16,9 +17,9 @@ export class Content {
   public getReminders(doneOnly: boolean = true): Array<Reminder> {
     const reminders = parseReminder(this.doc);
     if (!doneOnly) {
-      return reminders;
+      return reminders.filter(reminder => reminder.status != ReminderStatus.Done && reminder.status != ReminderStatus.Cancelled);
     }
-    return reminders.filter(reminder => !reminder.done);
+    return reminders.filter(reminder => reminder.status == ReminderStatus.Done);
   }
 
   public getTodos(): Array<Todo> {

--- a/src/model/format/markdown.test.ts
+++ b/src/model/format/markdown.test.ts
@@ -1,4 +1,5 @@
 import { MarkdownDocument, Todo } from "./markdown";
+import { ReminderStatus } from "model/format/reminder-base";
 
 describe('MarkdownDocument', (): void => {
   test('getTodos()', (): void => {
@@ -28,7 +29,7 @@ describe('MarkdownDocument', (): void => {
       ]);
 
     todos[0]!.body = "New Task1 ";
-    todos[0]!.setChecked(true);
+    todos[0]!.setStatus(ReminderStatus.Done);
     expect(doc.toMarkdown()).toEqual(`# TODO
         
 - [x] New Task1 

--- a/src/model/format/markdown.ts
+++ b/src/model/format/markdown.ts
@@ -3,13 +3,15 @@
  * 
  * This class shouldn't break original line.
  */
+import type { ReminderStatus } from "./reminder-base";
+
 export class Todo {
     // e.g: '  - [x] hello'
     // prefix: '  - [ '
-    // check: 'x'
+    // status: 'x' or ' ' or '/' or '-'
     // suffix: '] '
     // body: hello
-    private static readonly regexp = /^(?<prefix>((> ?)*)?\s*[\-\*][ ]+\[)(?<check>.)(?<suffix>\]\s+)(?<body>.*)$/;
+    private static readonly regexp = /^(?<prefix>((> ?)*)?\s*[\-\*][ ]+\[)(?<status>.)(?<suffix>\]\s+)(?<body>.*)$/;
 
     static parse(lineIndex: number, line: string): Todo | null {
         const match = Todo.regexp.exec(line);
@@ -17,7 +19,7 @@ export class Todo {
             return new Todo(
                 lineIndex,
                 match.groups!['prefix']!,
-                match.groups!['check']!,
+                match.groups!['status']!,
                 match.groups!['suffix']!,
                 match.groups!['body']!);
         }
@@ -27,24 +29,24 @@ export class Todo {
     constructor(
         public lineIndex: number,
         private prefix: string,
-        public check: string,
+        public status: string,
         private suffix: string,
         public body: string) { }
 
     public toMarkdown(): string {
-        return `${this.prefix}${this.check}${this.suffix}${this.body}`;
+        return `${this.prefix}${this.status}${this.suffix}${this.body}`;
     }
 
-    public isChecked() {
-        return this.check === 'x';
-    }
-
-    public setChecked(checked: boolean) {
-        this.check = checked ? 'x' : ' ';
+    public setStatus(status: ReminderStatus) {
+        this.status = <string> status;
     }
 
     public getHeaderLength() {
-        return this.prefix.length + this.check.length + this.suffix.length;
+        return this.prefix.length + this.status.length + this.suffix.length;
+    }
+
+    public getStatus() {
+        return <ReminderStatus> this.status;
     }
 
     public clone() {
@@ -53,7 +55,7 @@ export class Todo {
 }
 
 export type TodoEdit = {
-    checked?: boolean,
+    status?: string,
     body?: string,
 }
 

--- a/src/model/format/reminder-base.ts
+++ b/src/model/format/reminder-base.ts
@@ -7,11 +7,18 @@ import { Todo } from "./markdown";
 export type ReminderEdit = {
     time?: DateTime,
     rawTime?: string,
-    checked?: boolean
+    status?: ReminderStatus,
 }
 export type ReminderInsertion = {
     insertedLine: string,
     caretPosition: number,
+}
+
+export enum ReminderStatus {
+    Todo = " ",
+    Done = "x",
+    InProgress = "/",
+    Cancelled = "-",
 }
 
 export interface ReminderModel {
@@ -127,7 +134,7 @@ export abstract class TodoBasedReminderFormat<E extends ReminderModel> implement
                 if (time == null) {
                     return null;
                 }
-                return new Reminder(doc.file, title, time, todo.lineIndex, todo.isChecked());
+                return new Reminder(doc.file, title, time, todo.lineIndex, todo.getStatus());
             })
             .filter((reminder): reminder is Reminder => reminder != null);
     }
@@ -174,8 +181,8 @@ export abstract class TodoBasedReminderFormat<E extends ReminderModel> implement
         } else if (edit.time !== undefined) {
             parsed.setTime(edit.time);
         }
-        if (edit.checked !== undefined) {
-            todo.setChecked(edit.checked);
+        if (edit.status !== undefined) {
+            todo.setStatus(edit.status);
         }
         return true;
     }

--- a/src/model/format/reminder-default.test.ts
+++ b/src/model/format/reminder-default.test.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "model/time";
 import moment from "moment";
-import { ReminderFormatParameterKey } from "./reminder-base";
+import { ReminderFormatParameterKey, ReminderStatus } from "./reminder-base";
 import { ReminderFormatTestUtil } from "./reminder-base.test";
 import { DefaultReminderFormat } from "./reminder-default";
 
@@ -46,7 +46,7 @@ describe('DefaultReminderFormat', (): void => {
         await util.testModify({
             inputMarkdown: "- [ ] Task1 (@2021-09-14)",
             edit: {
-                checked: true,
+                status: ReminderStatus.Done,
                 time: new DateTime(moment("2021-09-15 10:00"), true)
             },
             expectedMarkdown: "- [x] Task1 (@2021-09-15 10:00)",
@@ -59,7 +59,7 @@ describe('DefaultReminderFormat', (): void => {
         await util.testModify({
             inputMarkdown: "- [ ] Task1 (@[[2021-09-14]] 09:00)",
             edit: {
-                checked: true,
+                status: ReminderStatus.Done,
                 time: new DateTime(moment("2021-09-15 10:00"), true)
             },
             expectedMarkdown: "- [x] Task1 (@[[2021-09-15]] 10:00)",

--- a/src/model/format/reminder-tasks-plugin.test.ts
+++ b/src/model/format/reminder-tasks-plugin.test.ts
@@ -2,7 +2,7 @@ import { MarkdownDocument } from "model/format/markdown";
 import { TasksPluginFormat, TasksPluginReminderModel } from "model/format/reminder-tasks-plugin";
 import { DateTime } from "model/time";
 import moment from "moment";
-import { ReminderFormatConfig, ReminderFormatParameterKey } from "./reminder-base";
+import { ReminderFormatConfig, ReminderFormatParameterKey, ReminderStatus } from "./reminder-base";
 
 describe('TasksPluginReminderLine', (): void => {
     test('parse()', (): void => {
@@ -132,6 +132,6 @@ async function testModify({
     if (reminders.length === 0 && expectedMarkdown === undefined) {
         return;
     }
-    await sut.modify(doc, reminders[0]!, { checked: true })
+    await sut.modify(doc, reminders[0]!, { status: ReminderStatus.Done })
     expect(doc.toMarkdown()).toBe(expectedMarkdown);
 }

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -2,7 +2,7 @@ import type { MarkdownDocument, Todo } from "model/format/markdown";
 import { DateTime, DATE_TIME_FORMATTER } from "model/time";
 import moment, { Moment } from "moment";
 import { RRule } from "rrule";
-import { ReminderEdit, ReminderFormatParameterKey, ReminderModel, TodoBasedReminderFormat } from "./reminder-base";
+import { ReminderEdit, ReminderFormatParameterKey, ReminderModel, ReminderStatus, TodoBasedReminderFormat } from "./reminder-base";
 import { splitBySymbol, Symbol, Tokens } from "./splitter";
 
 function removeTags(text: string): string {
@@ -194,8 +194,8 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
         if (!super.modifyReminder(doc, todo, parsed, edit)) {
             return false;
         }
-        if (edit.checked !== undefined) {
-            if (edit.checked) {
+        if (edit.status !== undefined) {
+            if (edit.status == ReminderStatus.Done) {
                 const recurrence = parsed.getRecurrence();
                 if (recurrence !== null) {
 
@@ -227,7 +227,7 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
                         nextReminder.setTime(nextDueDate);
                     }
                     nextReminderTodo.body = nextReminder.toMarkdown();
-                    nextReminderTodo.setChecked(false);
+                    nextReminderTodo.setStatus(ReminderStatus.Todo);
                     doc.insertTodo(todo.lineIndex, nextReminderTodo);
                 }
                 parsed.setDoneDate(this.config.getParameter(ReminderFormatParameterKey.now));

--- a/src/model/reminder.ts
+++ b/src/model/reminder.ts
@@ -20,7 +20,7 @@ export class Reminder {
     public title: string,
     public time: DateTime,
     public rowNumber: number,
-    public done: boolean
+    public status: string,
   ) { }
 
   key() {


### PR DESCRIPTION
This PR adds support for multiple statuses in tasks.

The main motivation for this is preventing notifications for cancelled tasks. It also applies to any condition where a task isn't "finished," but you don't want to be notified about it.

I ran `npm run test` and this doesn't introduce any new issues.