### PR TITLE
feat: Add feat keep silence, do not show builtin notification

### DIFF
--- a/src/plugin/notification-worker.ts
+++ b/src/plugin/notification-worker.ts
@@ -2,7 +2,7 @@ import type ReminderPlugin from "main";
 import type { Reminder } from "model/reminder";
 
 export class NotificationWorker {
-  constructor(private plugin: ReminderPlugin) {}
+  constructor(private plugin: ReminderPlugin) { }
 
   startPeriodicTask() {
     let intervalTaskRunning = true;
@@ -47,6 +47,10 @@ export class NotificationWorker {
       this.plugin.settings.reminderTime.value,
     );
 
+    if (this.plugin.settings.silence.value == true) {
+      // Do not show buildin notification
+      return
+    }
     let previousReminder: Reminder | undefined = undefined;
     for (const reminder of expired) {
       if (this.plugin.app.workspace.layoutReady) {

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -29,6 +29,7 @@ export class Settings {
   reminderTime: SettingModel<string, Time>;
   reminderTimeStep: SettingModel<number, number>;
   useSystemNotification: SettingModel<boolean, boolean>;
+  silence: SettingModel<boolean, boolean>;
   laters: SettingModel<string, Array<Later>>;
   dateFormat: SettingModel<string, string>;
   dateTimeFormat: SettingModel<string, string>;
@@ -67,6 +68,14 @@ export class Settings {
       .key("useSystemNotification")
       .name("Use system notification")
       .desc("Use system notification for reminder notifications")
+      .toggle(false)
+      .build(new RawSerde());
+
+    this.silence = this.settings
+      .newSettingBuilder()
+      .key("keepSilence")
+      .name("Keep silence")
+      .desc("Do not show buildin notification")
       .toggle(false)
       .build(new RawSerde());
 
@@ -221,6 +230,7 @@ export class Settings {
         this.reminderTimeStep,
         this.laters,
         this.useSystemNotification,
+        this.silence,
       );
     this.settings
       .newGroup("Editor")

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -31,9 +31,14 @@ export class ReminderPluginUI {
       this.plugin.settings.reminderTime,
       // On select a reminder in the list
       (reminder) => {
-        if (reminder.muteNotification) {
-          this.showReminder(reminder);
-          return;
+        if (this.plugin.settings.silence.value == true) {
+          // Do not show buildin notification
+        }
+        else {
+          if (reminder.muteNotification) {
+            this.showReminder(reminder);
+            return;
+          }
         }
         this.openReminderFile(reminder);
       },
@@ -201,7 +206,7 @@ export class ReminderPluginUI {
 class EditDetector {
   private lastModified?: Date;
 
-  constructor(private editDetectionSec: ReadOnlyReference<number>) {}
+  constructor(private editDetectionSec: ReadOnlyReference<number>) { }
 
   fileChanged() {
     this.lastModified = new Date();


### PR DESCRIPTION
If you have lots of reminder items and you don't want to show them all at starting. then, use silence mode to avoid the lots of builtin notification.