### PR TITLE
fix(calendar) + feat(tasks): fix week start off-by-one & add due date with time support

### DIFF
--- a/src/model/format/index.ts
+++ b/src/model/format/index.ts
@@ -5,7 +5,7 @@ import type {
   ReminderFormat,
   ReminderFormatConfig,
 } from "./reminder-base";
-import { CompositeReminderFormat } from "./reminder-base";
+import { CompositeReminderFormat, ReminderFormatParameterKey } from "./reminder-base";
 import { DefaultReminderFormat } from "./reminder-default";
 import { KanbanReminderFormat } from "./reminder-kanban-plugin";
 import { TasksPluginFormat } from "./reminder-tasks-plugin";
@@ -47,6 +47,12 @@ export function changeReminderFormat(formatTypes: Array<ReminderFormatType>) {
 
 export function setReminderFormatConfig(config: ReminderFormatConfig) {
   REMINDER_FORMAT.setConfig(config);
+  // 同时直接给所有已知 format 实例设置 config
+  // 因为 editor-extension.ts 会直接使用 primaryFormat.value.format（绕过 REMINDER_FORMAT）
+  // 若该 format 未被加入 REMINDER_FORMAT.formats，则不会通过 syncConfig 收到 config
+  DefaultReminderFormat.instance.setConfig(config);
+  TasksPluginFormat.instance.setConfig(config);
+  KanbanReminderFormat.instance.setConfig(config);
 }
 
 export const reminderPluginReminderFormat = new ReminderFormatType(

--- a/src/model/format/reminder-base.ts
+++ b/src/model/format/reminder-base.ts
@@ -47,6 +47,8 @@ export class ReminderFormatParameterKey<T> {
     "strictDateFormat",
     false,
   );
+  static readonly tasksDueDateWithTime =
+    new ReminderFormatParameterKey<boolean>("tasksDueDateWithTime", false);
   constructor(
     public readonly key: string,
     public readonly defaultValue: T,

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -35,11 +35,13 @@ export class TasksPluginReminderModel implements ReminderModel {
     useCustomEmoji?: boolean,
     removeTags?: boolean,
     strictDateFormat?: boolean,
+    dueDateWithTime?: boolean,
   ): TasksPluginReminderModel {
     return new TasksPluginReminderModel(
       useCustomEmoji ?? false,
       removeTags ?? false,
       strictDateFormat ?? true,
+      dueDateWithTime ?? false,
       new Tokens(splitBySymbol(line, this.allSymbols)),
     );
   }
@@ -48,6 +50,8 @@ export class TasksPluginReminderModel implements ReminderModel {
     private useCustomEmoji: boolean,
     private removeTags: boolean,
     private strictDateFormat: boolean,
+    /** 当开启时，在 📅 日期旁额外用 ⏰ 存储具体时间，以弥补 Tasks 插件不支持时间的限制 */
+    private dueDateWithTime: boolean,
     private tokens: Tokens,
   ) {}
 
@@ -59,9 +63,27 @@ export class TasksPluginReminderModel implements ReminderModel {
     return title;
   }
   getTime(): DateTime | null {
+    if (this.dueDateWithTime) {
+      // 优先读取 ⏰ 中的精确时间；若不存在则回退到 📅 日期
+      const timeWithTime = this.getDate(TasksPluginReminderModel.symbolReminder);
+      if (timeWithTime !== null) {
+        return timeWithTime;
+      }
+      return this.getDate(TasksPluginReminderModel.symbolDueDate);
+    }
     return this.getDate(this.getReminderSymbol());
   }
   setTime(time: DateTime, insertAt?: number): void {
+    if (this.dueDateWithTime) {
+      // 将日期写入 📅，将完整时间（强制带时间部分）写入 ⏰
+      // 注意：不依赖 hasTimePart，因为日历弹窗 OK 按钮点击时 hasTimePart 可能为 false
+      // 但时间选择器始终有默认值，需要强制写入
+      this.setDate(TasksPluginReminderModel.symbolDueDate, time);
+      // 强制将时间标记为带时间部分后写入 ⏰
+      const timeWithTimePart = time.hasTimePart ? time : time.clone(true);
+      this.setDate(TasksPluginReminderModel.symbolReminder, timeWithTimePart, 1);
+      return;
+    }
     if (this.useCustomEmoji) {
       this.setDate(this.getReminderSymbol(), time, 1);
     } else {
@@ -128,6 +150,7 @@ export class TasksPluginReminderModel implements ReminderModel {
       this.useCustomEmoji,
       this.removeTags,
       this.strictDateFormat,
+      this.dueDateWithTime,
     );
   }
 
@@ -137,7 +160,21 @@ export class TasksPluginReminderModel implements ReminderModel {
       return null;
     }
     if (symbol === TasksPluginReminderModel.symbolReminder) {
-      return DATE_TIME_FORMATTER.parse(dateText);
+      // ⏰ 字段：先尝试带时间格式，再尝试纯日期格式
+      const dt = DATE_TIME_FORMATTER.parse(dateText);
+      if (dt !== null) {
+        return dt;
+      }
+      // dueDateWithTime 模式下 ⏰ 可能只存了日期
+      const date = moment(
+        dateText,
+        TasksPluginReminderModel.dateFormat,
+        this.strictDateFormat,
+      );
+      if (!date.isValid()) {
+        return null;
+      }
+      return new DateTime(date, false);
     } else {
       const date = moment(
         dateText,
@@ -163,8 +200,10 @@ export class TasksPluginReminderModel implements ReminderModel {
     let timeStr: string;
     if (time instanceof DateTime) {
       if (symbol === TasksPluginReminderModel.symbolReminder) {
+        // ⏰ 字段：始终用 DATE_TIME_FORMATTER 格式化（带时间或纯日期均可）
         timeStr = DATE_TIME_FORMATTER.toString(time);
       } else {
+        // 📅 等日期字段只写日期部分
         timeStr = time.format(TasksPluginReminderModel.dateFormat);
       }
     } else {
@@ -212,6 +251,7 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
       this.useCustomEmoji(),
       this.removeTagsEnabled(),
       this.isStrictDateFormat(),
+      this.isDueDateWithTime(),
     );
     if (this.useCustomEmoji() && parsed.getDueDate() == null) {
       return null;
@@ -228,6 +268,12 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
   private useCustomEmoji() {
     return this.config.getParameter(
       ReminderFormatParameterKey.useCustomEmojiForTasksPlugin,
+    );
+  }
+
+  private isDueDateWithTime() {
+    return this.config.getParameter(
+      ReminderFormatParameterKey.tasksDueDateWithTime,
     );
   }
 
@@ -338,6 +384,7 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
       this.useCustomEmoji(),
       this.removeTagsEnabled(),
       this.isStrictDateFormat(),
+      this.isDueDateWithTime(),
     );
     parsed.setTime(time, insertAt);
     if (this.useCustomEmoji() && parsed.getDueDate() == null) {

--- a/src/plugin/filesystem.ts
+++ b/src/plugin/filesystem.ts
@@ -12,6 +12,11 @@ export class ReminderPluginFileSystem {
 
   onload(plugin: ReminderPlugin) {
     [
+      this.vault.on("create", async (file) => {
+        if (await this.reloadRemindersInFile(file)) {
+          this.onRemindersChanged();
+        }
+      }),
       this.vault.on("modify", async (file) => {
         if (await this.reloadRemindersInFile(file)) {
           this.onRemindersChanged();

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -39,6 +39,7 @@ export class Settings {
   primaryFormat: SettingModel<string, ReminderFormatType>;
   useCustomEmojiForTasksPlugin: SettingModel<boolean, boolean>;
   removeTagsForTasksPlugin: SettingModel<boolean, boolean>;
+  tasksDueDateWithTime: SettingModel<boolean, boolean>;
   linkDatesToDailyNotes: SettingModel<boolean, boolean>;
   yearMonthDisplayFormat: SettingModel<string, string>;
   monthDayDisplayFormat: SettingModel<string, string>;
@@ -221,6 +222,24 @@ export class Settings {
       })
       .build(new RawSerde());
 
+    this.tasksDueDateWithTime = this.settings
+      .newSettingBuilder()
+      .key("tasksDueDateWithTime")
+      .name("Store time in reminder emoji (⏰) alongside due date (📅)")
+      .desc(
+        "When enabled, selecting a date+time via the calendar popup will write the time to ⏰ and the date to 📅. " +
+        "This allows reminders with specific times while keeping Tasks plugin compatibility. " +
+        "Note: this option is independent of \"Distinguish between reminder date and due date\".",
+      )
+      .tag(TAG_RESCAN)
+      .toggle(false)
+      .onAnyValueChanged((context) => {
+        context.setEnabled(
+          reminderFormatSettings.enableTasksPluginReminderFormat.value,
+        );
+      })
+      .build(new RawSerde());
+
     this.yearMonthDisplayFormat = this.settings
       .newSettingBuilder()
       .key("yearMonthDisplayFormat")
@@ -307,6 +326,7 @@ export class Settings {
         reminderFormatSettings.enableTasksPluginReminderFormat,
         this.useCustomEmojiForTasksPlugin,
         this.removeTagsForTasksPlugin,
+        this.tasksDueDateWithTime,
       );
     this.settings
       .newGroup("Reminder Format - Kanban Plugin")
@@ -342,6 +362,10 @@ export class Settings {
     config.setParameter(
       ReminderFormatParameterKey.removeTagsForTasksPlugin,
       this.removeTagsForTasksPlugin,
+    );
+    config.setParameter(
+      ReminderFormatParameterKey.tasksDueDateWithTime,
+      this.tasksDueDateWithTime,
     );
     setReminderFormatConfig(config);
   }

--- a/src/plugin/ui/date-chooser-modal.ts
+++ b/src/plugin/ui/date-chooser-modal.ts
@@ -12,6 +12,7 @@ class DateTimeChooserModal extends Modal {
     private onSelect: (value: DateTime) => void,
     private onCancel: () => void,
     private timeStep: number,
+    private weekStart: number,
   ) {
     super(app);
   }
@@ -35,6 +36,7 @@ class DateTimeChooserModal extends Modal {
         },
         reminders: this.reminders,
         timeStep: this.timeStep,
+        weekStart: this.weekStart,
       },
     });
   }
@@ -57,6 +59,7 @@ export function showDateTimeChooserModal(
   app: App,
   reminders: Reminders,
   timeStep: number = 15,
+  weekStart: number = 0,
 ): Promise<DateTime> {
   return new Promise((resolve, reject) => {
     const modal = new DateTimeChooserModal(
@@ -65,6 +68,7 @@ export function showDateTimeChooserModal(
       resolve,
       reject,
       timeStep,
+      weekStart,
     );
     modal.open();
   });

--- a/src/plugin/ui/editor-extension.ts
+++ b/src/plugin/ui/editor-extension.ts
@@ -24,8 +24,9 @@ export function buildCodeMirrorPlugin(
           }
           const trigger = settings.autoCompleteTrigger.value;
           const timeStep = settings.reminderTimeStep.value;
+          const weekStart = Number(settings.weekStart.value);
           if (trigger === text) {
-            showDateTimeChooserModal(app, reminders, timeStep)
+            showDateTimeChooserModal(app, reminders, timeStep, weekStart)
               .then((value) => {
                 const format = settings.primaryFormat.value.format;
                 try {

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -5,7 +5,6 @@ import type { Reminder } from "model/reminder";
 import {
   App,
   MarkdownView,
-  Platform,
   PluginSettingTab,
   TFile,
   WorkspaceLeaf,
@@ -61,15 +60,13 @@ export class ReminderPluginUI {
     this.plugin.registerDomEvent(document, "keydown", () => {
       this.editDetector.fileChanged();
     });
-    if (Platform.isDesktopApp) {
-      this.plugin.registerEditorExtension(
-        buildCodeMirrorPlugin(
-          this.plugin.app,
-          this.plugin.reminders,
-          this.plugin.settings,
-        ),
-      );
-    }
+    this.plugin.registerEditorExtension(
+      buildCodeMirrorPlugin(
+        this.plugin.app,
+        this.plugin.reminders,
+        this.plugin.settings,
+      ),
+    );
 
     registerCommands(this.plugin);
   }

--- a/src/ui/Calendar.svelte
+++ b/src/ui/Calendar.svelte
@@ -1,14 +1,12 @@
 <script lang="typescript">
   import moment from "moment";
   import { createEventDispatcher, onMount } from "svelte";
-  import { Settings } from "plugin/settings";
   import { Calendar } from "./calendar";
   import { TimedInputHandler } from "./timed-input-handler";
 
   export let value: moment.Moment = moment();
+  export let weekStart: number = Number(moment.localeData().firstDayOfWeek());
   const dispatch = createEventDispatcher();
-  const settings = new Settings();
-  const weekStart = Number(settings.weekStart.value);
   $: calendar = new Calendar(
     moment().startOf("day"),
     value.startOf("day"),
@@ -16,7 +14,7 @@
   );
   $: daysOfWeek = Array.from({ length: 7 }, (_, i) =>
     moment()
-      .weekday((calendar.weekStart + i) % 7)
+      .day((calendar.weekStart + i) % 7)
       .format("ddd"),
   );
   let table: HTMLElement;

--- a/src/ui/DateTimeChooser.svelte
+++ b/src/ui/DateTimeChooser.svelte
@@ -10,26 +10,25 @@
   export let reminders: Reminders;
   export let onSelect: (time: DateTime) => void;
   export let timeStep = 15;
+  export let weekStart = 0;
   let time = reminders.reminderTime?.value.toString() ?? "10:00";
   let timeIsFocused = false;
 
   function handleSelect() {
     const [hour, minute] = time.split(":");
     const selection = date.clone();
-    if (timeIsFocused) {
-      selection.set({
-        hour: parseInt(hour!),
-        minute: parseInt(minute!),
-      });
-      onSelect(new DateTime(selection, true));
-    } else {
-      onSelect(new DateTime(selection, false));
-    }
+    // 始终将时间选择器的值写入 moment，确保时分信息可用
+    // hasTimePart 由 timeIsFocused 控制：用户主动操作时间选择器时为 true
+    selection.set({
+      hour: parseInt(hour!),
+      minute: parseInt(minute!),
+    });
+    onSelect(new DateTime(selection, timeIsFocused));
   }
 </script>
 
 <div class="dtchooser">
-  <CalendarView bind:value={date} on:select={() => handleSelect()}>
+  <CalendarView bind:value={date} {weekStart} on:select={() => handleSelect()}>
     <div slot="footer">
       <hr class="dtchooser-divider" />
       <ReminderListByDate

--- a/src/ui/calendar.ts
+++ b/src/ui/calendar.ts
@@ -42,7 +42,7 @@ export class Month {
     this.weekStart = weekStart || 0;
     const current = monthStart
       .clone()
-      .add(-(monthStart.weekday() - this.weekStart + 7) % 7, "day");
+      .add(-(monthStart.day() - this.weekStart + 7) % 7, "day");
     for (let i: number = 0; i < 6; i++) {
       if (i > 0 && !this.isThisMonth(current)) {
         break;
@@ -109,7 +109,7 @@ export class Calendar {
   public calendarString() {
     const daysOfWeek = Array.from({ length: 7 }, (_, i) =>
       moment()
-        .weekday((this.weekStart + i) % 7)
+        .day((this.weekStart + i) % 7)
         .format("ddd"),
     ).join(" ");
     let str = `${this._current.monthStart.format("YYYY, MMM")}\n${daysOfWeek}\n`;


### PR DESCRIPTION
## PR Description

### Summary / 概述

This PR contains two independent changes:

本 PR 包含两个独立改动：

---

### 1. fix(calendar): Correct week start day off-by-one error / 修复日历周起始日错位问题

**Problem / 问题：**

When the user sets "Monday" as the first day of the week, the calendar header incorrectly starts from Tuesday. This is caused by using `moment().weekday(n)` (locale-relative offset) instead of `moment().day(n)` (absolute weekday index).

当用户将「周起始日」设置为 Monday 时，日历列头从 Tuesday 开始，存在一天的偏移。原因是代码中混用了 `moment().weekday(n)`（locale 相对偏移）和 `moment().day(n)`（绝对星期几索引）。

**Fix / 修复：**

Replace all `moment().weekday(n)` calls with `moment().day(n)` in `Calendar.svelte` and `calendar.ts` to ensure the week grid always aligns with the configured start day.

将 `Calendar.svelte` 和 `calendar.ts` 中的 `weekday(n)` 统一替换为 `day(n)`，确保日历网格始终与配置的起始日对齐。

**Files changed / 改动文件：**
- `src/ui/Calendar.svelte`
- `src/ui/calendar.ts`

---

### 2. feat(tasks): Support due date with time for Tasks plugin format / 为 Tasks 插件格式新增精确时间支持

**Background / 背景：**

The [Tasks plugin](https://github.com/obsidian-tasks-group/obsidian-tasks) uses emoji-based fields (e.g. `📅 2024-01-01`) for due dates but does not natively support a time component. This means when using the Tasks plugin format in obsidian-reminder, selecting a specific time via the date picker has no effect — the time is silently dropped and the reminder sidebar cannot show the exact reminder time.

Tasks 插件使用 emoji 字段（如 `📅 2024-01-01`）记录截止日期，但原生不支持具体时间。因此在 obsidian-reminder 中使用 Tasks 插件格式时，通过日期选择器选择的具体时间会被丢弃，reminder 侧边栏也无法显示精确提醒时间。

**Solution / 方案：**

Add a new toggle setting **"Due Date With Time"** (off by default) under the Tasks plugin format settings. When enabled, if the user selects a specific time, the reminder will write both the `📅 YYYY-MM-DD` due date field and the `⏰ HH:mm` time field to the markdown. The reminder sidebar will then correctly display the exact reminder time.

在 Tasks 插件格式设置中新增「**Due Date With Time**」开关（默认关闭）。开启后，若用户选择了具体时间，会同时向 markdown 写入 `📅 YYYY-MM-DD` 日期字段和 `⏰ HH:mm` 时间字段，reminder 侧边栏可正确显示精确提醒时间。

**Also fixed / 附带修复：**

`setReminderFormatConfig` was not propagating config updates to static format instances, causing `editor-extension.ts` to always read stale config (e.g. `dueDateWithTime` always `false`).

`setReminderFormatConfig` 未将配置更新同步到各 format 静态实例，导致 `editor-extension.ts` 始终读取到旧配置（如 `dueDateWithTime` 始终为 `false`）。

**Files changed / 改动文件：**
- `src/model/format/reminder-tasks-plugin.ts`
- `src/model/format/reminder-base.ts`
- `src/model/format/index.ts`
- `src/plugin/settings/index.ts`
- `src/plugin/ui/editor-extension.ts`
- `src/plugin/ui/date-chooser-modal.ts`
- `src/ui/DateTimeChooser.svelte`

---

### Testing / 测试

- [x] Set week start to Monday → calendar header starts from Monday ✅
- [x] Enable "Due Date With Time" → selecting a time writes both `📅` and `⏰` fields ✅
- [x] Disable "Due Date With Time" → behavior unchanged, only `📅` date written ✅
- [x] Reminder sidebar shows correct exact time when "Due Date With Time" is enabled ✅