### PR TITLE
chore: align obsidian/electron/@types/node with current platform versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,11 @@
         "@codemirror/view": "^6.4.0",
         "@tsconfig/svelte": "^5.0.4",
         "@types/jest": "^29.2.5",
-        "@types/node": "^14.14.37",
+        "@types/node": "^22.20.1",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "builtin-modules": "^3.3.0",
         "cross-env": "^7.0.3",
-        "electron": "^28.3.3",
+        "electron": "^39.8.10",
         "esbuild": "^0.24.0",
         "esbuild-svelte": "^0.9.0",
         "eslint": "^9.17.0",
@@ -38,7 +38,7 @@
         "jest": "^29.2.5",
         "jest-environment-jsdom": "^29.7.0",
         "moment": "^2.29.4",
-        "obsidian": "^1.7.2",
+        "obsidian": "^1.13.1",
         "prettier-plugin-svelte": "^3.3.2",
         "svelte-check": "^4.1.1",
         "svelte-jester": "^5.0.0",
@@ -616,10 +616,14 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.2.tgz",
-      "integrity": "sha512-Mxff85Hp5va+zuj+H748KbubXjrinX/k28lj43H14T2D0+4kuvEFIEIO7hCEcvBT8ubZyIelt9yGOjj2MWOEQA==",
-      "dev": true
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
     },
     "node_modules/@codemirror/stream-parser": {
       "version": "0.19.3",
@@ -676,13 +680,15 @@
       "dev": true
     },
     "node_modules/@codemirror/view": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.4.0.tgz",
-      "integrity": "sha512-Kv32b6Tn7QVwFbj/EDswTLSocjk5kgggF6zzBFAL4o4hZ/vmtFD155+EjH1pVlbfoDyVC2M6SedPsMrwYscgNg==",
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@codemirror/state": "^6.0.0",
-        "style-mod": "^4.0.0",
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
     },
@@ -1701,6 +1707,13 @@
         "@lezer/common": "^0.15.0"
       }
     },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1967,10 +1980,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.17.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.11.tgz",
-      "integrity": "sha512-n2OQ+0Bz6WEsUjrvcHD1xZ8K+Kgo4cn9/w94s1bJS690QMUWfJPW/m7CCb7gPkA1fcYwL2UpjXP/rq/Eo41m6w==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -3046,10 +3063,11 @@
       }
     },
     "node_modules/crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==",
-      "dev": true
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -3386,14 +3404,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.3.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-28.3.3.tgz",
-      "integrity": "sha512-ObKMLSPNhomtCOBAxFS8P2DW/4umkh72ouZUlUKzXGtYuPzgr1SYhskhFWgzAsPtUzhL2CzyV2sfbHcEW4CXqw==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron/get": "^2.0.0",
-        "@types/node": "^18.11.18",
+        "@types/node": "^22.7.7",
         "extract-zip": "^2.0.1"
       },
       "bin": {
@@ -3408,15 +3427,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
       "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
       "dev": true
-    },
-    "node_modules/electron/node_modules/@types/node": {
-      "version": "18.19.69",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.69.tgz",
-      "integrity": "sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6774,17 +6784,18 @@
       }
     },
     "node_modules/obsidian": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.7.2.tgz",
-      "integrity": "sha512-k9hN9brdknJC+afKr5FQzDRuEFGDKbDjfCazJwpgibwCAoZNYHYV8p/s3mM8I6AsnKrPKNXf8xGuMZ4enWelZQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+      "integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/codemirror": "5.60.8",
         "moment": "2.29.4"
       },
       "peerDependencies": {
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6"
       }
     },
     "node_modules/once": {
@@ -8013,10 +8024,11 @@
       }
     },
     "node_modules/style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==",
-      "dev": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
@@ -8610,10 +8622,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "@codemirror/view": "^6.4.0",
     "@tsconfig/svelte": "^5.0.4",
     "@types/jest": "^29.2.5",
-    "@types/node": "^14.14.37",
+    "@types/node": "^22.20.1",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "builtin-modules": "^3.3.0",
     "cross-env": "^7.0.3",
-    "electron": "^28.3.3",
+    "electron": "^39.8.10",
     "esbuild": "^0.24.0",
     "esbuild-svelte": "^0.9.0",
     "eslint": "^9.17.0",
@@ -40,7 +40,7 @@
     "jest": "^29.2.5",
     "jest-environment-jsdom": "^29.7.0",
     "moment": "^2.29.4",
-    "obsidian": "^1.7.2",
+    "obsidian": "^1.13.1",
     "prettier-plugin-svelte": "^3.3.2",
     "svelte-check": "^4.1.1",
     "svelte-jester": "^5.0.0",
@@ -55,9 +55,6 @@
   },
   "engines": {
     "node": ">=22.0.0"
-  },
-  "overrides": {
-    "@electron/get": "2.0.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,17 @@ import {
 } from "plugin";
 import { Reminders } from "model/reminder";
 import { DATE_TIME_FORMATTER } from "model/time";
+import type { Settings } from "plugin/settings";
 import { App, Plugin } from "obsidian";
 import type { PluginManifest } from "obsidian";
 
 export default class ReminderPlugin extends Plugin {
   _data: PluginData;
+  // `Plugin.settings` is declared as `settings?: unknown` since obsidian 1.13.0.
+  // We override it with the concrete `Settings` type here. It has to be a plain
+  // field (not a getter) because TypeScript doesn't allow overriding a base
+  // class property with an accessor.
+  override settings: Settings;
   private _ui: ReminderPluginUI;
   private _reminders: Reminders;
   private _fileSystem: ReminderPluginFileSystem;
@@ -25,6 +31,10 @@ export default class ReminderPlugin extends Plugin {
       this.data.changed = true;
     });
     this._data = new PluginData(this, this.reminders);
+    // `data.settings` always returns the same `Settings` instance for the
+    // lifetime of the plugin (only its values change on reload), so it's
+    // safe to capture the reference once here.
+    this.settings = this.data.settings;
     this.reminders.reminderTime = this.settings.reminderTime;
     DATE_TIME_FORMATTER.setTimeFormat(
       this.settings.dateFormat,
@@ -71,9 +81,5 @@ export default class ReminderPlugin extends Plugin {
 
   get data() {
     return this._data;
-  }
-
-  get settings() {
-    return this.data.settings;
   }
 }

--- a/src/plugin/ui/autocomplete.ts
+++ b/src/plugin/ui/autocomplete.ts
@@ -4,6 +4,10 @@ import type { DateTime } from "model/time";
 import { App, Platform } from "obsidian";
 import type { EditorPosition } from "obsidian";
 import type { ReminderFormatType } from "model/format";
+// obsidian's own type definitions dropped their (unused) re-export of the
+// legacy CodeMirror 5 types in 1.13, so import them directly here for the
+// Live Preview CM5 compatibility workaround below.
+import type * as CodeMirror from "codemirror";
 import { showDateTimeChooserModal } from "./date-chooser-modal";
 import { DateTimeChooserView } from "./datetime-chooser";
 

--- a/src/plugin/ui/datetime-chooser.ts
+++ b/src/plugin/ui/datetime-chooser.ts
@@ -2,6 +2,10 @@ import type { Reminders } from "model/reminder";
 import type { DateTime } from "model/time";
 import moment from "moment";
 import DateTimeChooser from "ui/DateTimeChooser.svelte";
+// obsidian's own type definitions dropped their (unused) re-export of the
+// legacy CodeMirror 5 types in 1.13, so import them directly here for the
+// Live Preview CM5 compatibility workaround.
+import type * as CodeMirror from "codemirror";
 
 export class DateTimeChooserView {
   private view: HTMLElement;

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -226,7 +226,7 @@ export class ReminderSettingTab extends PluginSettingTab {
     super(app, plugin);
   }
 
-  display(): void {
+  override display(): void {
     const { containerEl } = this;
 
     this.plugin.settings.settings.displayOn(containerEl);


### PR DESCRIPTION
## Summary

Aligns the plugin's build-time type definitions with the platform Obsidian actually ships today. Only `devDependencies` (type definitions / tooling) are touched — no runtime `dependencies` (`rrule`, `svelte`) were changed, and `manifest.json` / `versions.json` are untouched.

| Package | Old | New |
| --- | --- | --- |
| `obsidian` | `^1.7.2` | `^1.13.1` |
| `electron` | `^28.3.3` | `^39.8.10` |
| `@types/node` | `^14.14.37` | `^22.20.1` |

### Why electron 39.x, not the npm-latest 43.x

The plugin's runtime `electron` module is never bundled — `src/plugin/ui/reminder.ts` and `src/plugin/ui/util.ts` obtain it via `window.require("electron")`, i.e. whatever Electron build the user's installed Obsidian app embeds. The `electron` package in `devDependencies` exists purely so TypeScript has type definitions to check against; it has no effect on what actually runs.

Current Obsidian installers (1.12.7+) embed **Electron 39** (39.8.3). To keep the type definitions honest for what's actually running, this PR pins to the latest available 39.x patch release (`39.8.10`) rather than jumping to whatever is newest on npm (currently 40.x/43.x), which would type-check against an Electron API surface Obsidian doesn't actually ship yet.

### `@types/node`

Bumped to the latest `22.x` release (`22.20.1`) to match the Node version this repo builds/tests with (mise-managed Node 22.17.1), not npm's newest major (`24.x`).

### `manifest.json` (`minAppVersion`) left at `1.0.3`

This PR does not touch `manifest.json`. None of the changes here rely on newer Obsidian plugin APIs — `obsidian` was only bumped for type-checking accuracy, not because a new API is used. Raising `minAppVersion` would only be warranted if the code started depending on APIs introduced after 1.0.3, which it doesn't.

### `overrides["@electron/get"]` removed

The pinned `"@electron/get": "2.0.2"` override (previously pinning around an installation problem with old `electron`) was dropped and `npm install` was re-run from scratch. Electron 39 resolves and installs cleanly with `@electron/get@2.0.2` pulled in transitively by `electron` itself — no override needed anymore.

### Code changes required by the type bump

The obsidian 1.13 type definitions introduced a couple of breaking changes for this codebase:

- `Plugin` now declares `settings?: unknown` (new in 1.13.0). `ReminderPlugin` previously exposed a `get settings()` accessor of the same name, which TypeScript no longer allows (overriding a base property with an accessor is a hard error, not just a missing-`override` warning). Converted `settings` from a getter into a plain field assigned once in the constructor — safe, because `PluginData.settings` always returns the same `Settings` instance for the plugin's lifetime, only its internal values change.
- obsidian's `.d.ts` in 1.13 dropped its (now-unused) internal re-export of legacy CodeMirror 5 types, which this plugin was relying on as an implicit global (`CodeMirror.Editor`, `CodeMirror.EditorChange`) in `src/plugin/ui/autocomplete.ts` and `src/plugin/ui/datetime-chooser.ts` for a Live Preview CM5 compatibility fallback path. Added explicit `import type * as CodeMirror from "codemirror"` in both files (`@types/codemirror` is still available — it's a direct dependency of the `obsidian` package itself).
- `PluginSettingTab.display()` and the new `Plugin.settings` override both needed an explicit `override` modifier (`noImplicitOverride` is enabled in `tsconfig.json`).

None of these change runtime behavior — they're purely satisfying stricter/updated type definitions.

## Verification (all via `mise exec --`)

- `npm install` — resolves cleanly without the `@electron/get` override
- `npm run build` (esbuild) — passes
- `npm test` (Jest) — 9 suites / 45 tests, all passing
- `npm run lint` (eslint + `tsc --noEmit` + svelte-check) — 0 errors, 0 warnings
- `npx tsc --noEmit --pretty` — 0 errors

## Note

`electron.remote.Notification` (used in `src/plugin/ui/reminder.ts`, accessed via `as any`) can't be exercised in CI since it depends on the real Electron runtime embedded in Obsidian. **Manual verification of reminder notifications in an actual Obsidian installation is recommended before release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)