### PR TITLE
chore: migrate to Svelte 5

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -46,6 +46,15 @@ const ctx = await esbuild.context({
     minify: prod,
     plugins: [
         esbuildSvelte({
+            compilerOptions: {
+                // Keep the Svelte 4-style `new Component({ target, props })`
+                // constructor (plus `.$set()`/`.$destroy()`) working, since
+                // plugin/ui/*.ts instantiates Svelte components that way.
+                // Without this, Svelte 5 throws `component_api_invalid_new`
+                // at runtime (a regression tests can't catch, since no test
+                // imports a .svelte file - see .claude/rules/testing.md).
+                compatibility: { componentApi: 4 },
+            },
             preprocess: sveltePreprocess(),
         }),
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "rrule": "^2.8.1",
-        "svelte": "^4.2.18"
+        "svelte": "^5.56.4"
       },
       "devDependencies": {
         "@codemirror/commands": "6.10.2",
@@ -38,7 +38,7 @@
         "jest-environment-jsdom": "^30.4.1",
         "moment": "^2.30.1",
         "obsidian": "^1.13.1",
-        "prettier-plugin-svelte": "^3.5.2",
+        "prettier-plugin-svelte": "^4.1.1",
         "svelte-check": "^4.7.2",
         "svelte-jester": "^5.0.0",
         "svelte-preprocess": "^6.0.5",
@@ -48,19 +48,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2100,7 +2087,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2254,6 +2240,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8.9.0"
       }
     },
     "node_modules/@sveltejs/load-config": {
@@ -2496,6 +2491,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -2665,7 +2666,7 @@
       "version": "8.63.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
       "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3194,9 +3195,9 @@
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -3867,6 +3868,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3876,19 +3886,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/code-red": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@types/estree": "^1.0.1",
-        "acorn": "^8.10.0",
-        "estree-walker": "^3.0.3",
-        "periscopic": "^3.1.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -3970,19 +3967,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -4229,6 +4213,12 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -5004,6 +4994,12 @@
         "node": "*"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -5062,6 +5058,23 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/esrap": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+      "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -5083,15 +5096,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/esutils": {
@@ -7510,12 +7514,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "license": "CC0-1.0"
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -8116,17 +8114,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/periscopic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^3.0.0",
-        "is-reference": "^3.0.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8404,14 +8391,17 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.2.tgz",
-      "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-4.1.1.tgz",
+      "integrity": "sha512-wXvbXMjSvb4C9ENWTHXyd+ihakKCsJ6rJhLP6/8HFNj4GkZr48jqL9PoKsl2sk7SyCZRTnJ7O2TTowUpOxP/KA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
       "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -9019,6 +9009,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9361,28 +9352,30 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
-      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/estree": "^1.0.1",
-        "acorn": "^8.9.0",
-        "aria-query": "^5.3.0",
-        "axobject-query": "^4.0.0",
-        "code-red": "^1.0.3",
-        "css-tree": "^2.3.1",
-        "estree-walker": "^3.0.3",
-        "is-reference": "^3.0.1",
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "periscopic": "^3.1.0"
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/svelte-check": {
@@ -10642,6 +10635,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest-environment-jsdom": "^30.4.1",
     "moment": "^2.30.1",
     "obsidian": "^1.13.1",
-    "prettier-plugin-svelte": "^3.5.2",
+    "prettier-plugin-svelte": "^4.1.1",
     "svelte-check": "^4.7.2",
     "svelte-jester": "^5.0.0",
     "svelte-preprocess": "^6.0.5",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "rrule": "^2.8.1",
-    "svelte": "^4.2.18"
+    "svelte": "^5.56.4"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary

**This PR is stacked on #288; merge #288 first.** It was rebased onto `chore/eslint-10-tooling-majors` (not `master`) to resolve overlapping changes between the two PRs — both bumped `eslint-plugin-svelte` to `^3.20.0` and both added `{#each}` key expressions to satisfy `svelte/require-each-key`. The each-key implementation now uses #288's `Week.key` getter on `src/ui/calendar.ts`'s `Week` class (and `day.date.valueOf()` as the day key) rather than this PR's original local `weekKey()` helper in `Calendar.svelte`, so there is a single canonical implementation instead of two. Once #288 merges, GitHub will automatically retarget this PR's base to `master`.

Migrates the plugin from Svelte 4 to Svelte 5.

| Package | Before | After | Note |
| --- | --- | --- | --- |
| `svelte` | `^4.2.18` | `^5.56.4` | major bump |
| `prettier-plugin-svelte` | `^3.5.2` | `^4.1.1` | Svelte-5-only major |
| `eslint-plugin-svelte` | `^2.46.1` | `^3.20.0` | needed for Svelte 5 lint support (peerDependency `svelte: ^3.37.0 \|\| ^4.0.0 \|\| ^5.0.0`) |
| `esbuild-svelte` | `^0.9.5` | unchanged | peerDependency already allows `svelte: >=4.2.1 <6` |
| `svelte-preprocess` | `^6.0.5` | unchanged | peerDependency already allows `svelte: ^4.0.0 \|\| ^5.0.0-next.100 \|\| ^5.0.0` |
| `svelte-jester` | `^5.0.0` | unchanged | peerDependency already allows `svelte: >= 3` (not actually wired into jest's `transform`, so it doesn't matter in practice — see below) |
| `svelte-check` | `^4.7.2` | unchanged | peerDependency already allows `svelte: ^4.0.0 \|\| ^5.0.0-next.0` |
| `@tsconfig/svelte` | `^5.0.8` | unchanged | no `svelte` peerDependency |

`svelte-eslint-parser` (a transitive dependency of `eslint-plugin-svelte`, imported directly by `eslint.config.js` but not listed in `package.json`) moved from `0.43.0` to `1.8.0` automatically as part of the `eslint-plugin-svelte` bump.

- Did not use `npx sv migrate svelte-5`. The repo has only 8 `.svelte` files and 4 TS call sites that mount them, so they were reviewed and fixed by hand instead — safer for keeping behavior identical, since the migration tool tends to rune-ify components more aggressively than needed here.
- **`esbuild.config.mjs`**: added `compilerOptions.compatibility.componentApi: 4` to the `esbuild-svelte` plugin options. All of `plugin/ui/reminder.ts`, `plugin/ui/datetime-chooser.ts`, `plugin/ui/reminder-list.ts`, and `plugin/ui/date-chooser-modal.ts` instantiate Svelte components the Svelte-4 way (`new Component({ target, props })`, `.$set(...)`, `.$destroy()`). Svelte 5 defaults `compatibility.componentApi` to `5`, which throws `component_api_invalid_new` at runtime instead of compiling the legacy class wrapper. Since no jest test imports a `.svelte` file (`svelte-jester` is a listed dependency but was never wired into `package.json`'s jest `transform`, confirmed in `.claude/rules/testing.md`), this would have been a silent runtime-only regression invisible to CI. Verified the compiled `main.js` now contains `createClassComponent(...)` for these components (confirming the legacy constructor path is active) before switching back to the minified production build.
- **`.svelte` components**: no runes conversion — components stay on `export let`/legacy reactivity (`$:`), which Svelte 5 still fully supports. The only required change was adding a key expression to 5 `{#each}` blocks across `Calendar.svelte`, `Reminder.svelte`, `ReminderList.svelte`, `ReminderListByDate.svelte`, and `TimePicker.svelte`, since `eslint-plugin-svelte@3` enables `svelte/require-each-key` by default. Keys were chosen to be stable and match the item's natural identity (e.g. `reminder.key()`, the each item's index where it's already used as the option value, formatted dates for calendar days) so list identity/DOM reuse semantics are unchanged.
- `src/ui/Calendar.svelte` originally needed an additional fix here: keying weeks by `week.days[0].date` tripped `noUncheckedIndexedAccess` in `svelte-check`, so a small typed helper function `weekKey(week: Week)` was added locally. After rebasing onto #288 (see note above), this was superseded by #288's `Week.key` getter on `src/ui/calendar.ts`, so the local `weekKey()` helper and the `Week` import were removed from `Calendar.svelte` in favor of that shared implementation.
- No changes to `plugin/ui/*.ts` mounting code itself — thanks to the `componentApi: 4` compatibility flag, the existing `new Component(...)`/`.$set()`/`.$destroy()` call sites keep compiling and type-checking without modification.

## Verification

- `rm -rf node_modules && npm install` — resolves cleanly, no ERESOLVE, no `--legacy-peer-deps`/`--force`.
- `npm ci` — clean install from the regenerated lockfile.
- `npm run build` — production build succeeds; confirmed the previous (Svelte 4) `new Component()` mounting sites compile to the Svelte 5 legacy-class wrapper (`createClassComponent`) rather than throwing.
- `npm test` — all 45 Jest tests pass (these only exercise `src/model/` and `src/ui/calendar.ts`, not `.svelte` files, so they don't independently verify UI rendering — see below).
- `npm run lint` (eslint + `tsc --noEmit` + `svelte-check`) — 0 errors, 0 warnings.

**Note:** actual on-screen rendering/behavior of the UI (settings tab, reminder modal, reminder list view, date/time chooser) cannot be verified from CI/tests alone — please do a quick manual check in a real Obsidian vault before merging, especially the notification modal (`Reminder.svelte`) and the reminder list/date chooser popups, since those are the components that rely on the legacy imperative mount API this PR keeps alive via the `componentApi: 4` compatibility flag.

**Note:** this PR regenerates `package-lock.json` and may conflict with other open dependency PRs; merge them one at a time and rebase/regenerate the lockfile as needed.

## Test plan

- [x] `npm run build`
- [x] `npm test` (45/45)
- [x] `npm run lint`
- [ ] Manual smoke test in a real Obsidian vault: settings tab, reminder notification modal, reminder list view, date/time chooser popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
