### PR TITLE
chore: ignore dependabot updates incompatible with current toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    ignore:
+      # obsidian declares an exact peer dependency on @codemirror/state
+      # (currently 6.5.0), so newer @codemirror/* versions break npm install
+      - dependency-name: "@codemirror/*"
+      # prettier-plugin-svelte v4 requires Svelte 5; drop this once the
+      # project migrates from Svelte 4
+      - dependency-name: prettier-plugin-svelte
+        versions: [">=4"]
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Adds `ignore` rules to the npm dependabot config:

- **@codemirror/\***: `obsidian` declares an exact peer dependency on `@codemirror/state` (currently 6.5.0), so bumping any @codemirror package breaks `npm install` (see #283, which fails CI for this reason).
- **prettier-plugin-svelte >=4**: v4 requires Svelte 5 while this project is still on Svelte 4 (see #279, whose `npm install` fails with ERESOLVE). Drop this rule after migrating to Svelte 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)