### PR TITLE
chore: drop obsolete prettier-plugin-svelte ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,10 @@ updates:
       # obsidian declares an exact peer dependency on @codemirror/state
       # (currently 6.5.0), so newer @codemirror/* versions break npm install
       - dependency-name: "@codemirror/*"
+      # electron is pinned to the major that current Obsidian installers
+      # embed (see #282); bump manually when Obsidian ships a newer one
+      - dependency-name: electron
+        versions: [">=40"]
     groups:
       minor-and-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
       # embed (see #282); bump manually when Obsidian ships a newer one
       - dependency-name: electron
         versions: [">=40"]
+      # TypeScript >=6 (and the native TS7 compiler) is not yet supported
+      # by typescript-eslint, ts-jest, svelte-check, svelte-preprocess and
+      # esbuild-svelte; revisit once the ecosystem catches up (see #292)
+      - dependency-name: typescript
+        versions: [">=6"]
     groups:
       minor-and-patch:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,6 @@ updates:
       # obsidian declares an exact peer dependency on @codemirror/state
       # (currently 6.5.0), so newer @codemirror/* versions break npm install
       - dependency-name: "@codemirror/*"
-      # prettier-plugin-svelte v4 requires Svelte 5; drop this once the
-      # project migrates from Svelte 4
-      - dependency-name: prettier-plugin-svelte
-        versions: [">=4"]
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
The project migrated to Svelte 5 (#289) and package.json is already on prettier-plugin-svelte ^4.1.1, so the `>=4` ignore rule added in #290 now only blocks legitimate 4.x updates. The @codemirror/* rule stays: obsidian 1.13.1 still declares exact peer dependencies on @codemirror/state 6.5.0 / @codemirror/view 6.38.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)