### PR TITLE
chore: ignore eslint 10 until eslint-plugin-import supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,11 @@ updates:
       # esbuild-svelte; revisit once the ecosystem catches up (see #292)
       - dependency-name: typescript
         versions: [">=6"]
+      # eslint-plugin-import only supports eslint up to ^9 (see #293);
+      # remove once it supports eslint 10 or after migrating to
+      # eslint-plugin-import-x
+      - dependency-name: eslint
+        versions: [">=10"]
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Adds an ignore rule for `eslint >=10`: `eslint-plugin-import@2.32.0` (latest) only declares peer support up to eslint ^9, so the eslint 10 bump (#293) fails `npm install` with ERESOLVE — the same blocker that kept #288 on eslint 9. All other plugins are already eslint-10-ready.

Remove this rule once eslint-plugin-import supports eslint 10, or after migrating to `eslint-plugin-import-x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)