### PR TITLE
chore: ignore @types/node majors beyond the toolchain's Node version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,10 @@ updates:
       # eslint-plugin-import-x
       - dependency-name: eslint
         versions: [">=10"]
+      # @types/node is kept in sync with the Node major this repo builds
+      # and tests with (see #282); bump manually together with the toolchain
+      - dependency-name: "@types/node"
+        versions: [">=23"]
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Adds an ignore rule for `@types/node >=23`: per the policy in #282, `@types/node` tracks the Node major this repo builds and tests with (mise-managed Node 22, CI node-version 22), not npm's newest major. Dependabot proposed 26.x in #297, which was closed. Bump manually together with the toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)