### PR TITLE
Maintainability improvements: enforce CI checks, fix latent bugs, reduce coupling

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,10 +25,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check version consistency
+        run: node scripts/check-versions.mjs
+
       - name: Lint with ESLint
         continue-on-error: true
         run: |
-          npm run lint
+          npx eslint
 
       - name: Annotate ESLint results
         uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
@@ -38,6 +41,11 @@ jobs:
           reporter: github-pr-review
           filter_mode: nofilter
           fail_level: any
+
+      - name: Type check
+        run: |
+          npx tsc --noEmit --pretty
+          npx svelte-check
 
       - name: Test
         run: npm run test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   - pull_request
 
+env:
+  # The electron package is only used for its TypeScript types; skip the
+  # ~100MB binary download (electron's install.js honors this variable).
+  ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -9,6 +9,9 @@ on:
 
 env:
   PLUGIN_NAME: obsidian-reminder
+  # The electron package is only used for its TypeScript types; skip the
+  # ~100MB binary download (electron's install.js honors this variable).
+  ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
 jobs:
   release-beta:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 
 env:
   PLUGIN_NAME: obsidian-reminder
+  # The electron package is only used for its TypeScript types; skip the
+  # ~100MB binary download (electron's install.js honors this variable).
+  ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
 jobs:
   gh-pages:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,8 @@ const config = {
       },
     ],
     'unused-imports/no-unused-imports': 'error',
-    'no-console': 'off',
+    'no-console': ['error', { allow: ['warn', 'error', 'debug'] }],
+    'no-restricted-imports': ['error', { patterns: [{ group: ['../*'], message: 'Use src-rooted import paths (e.g. "model/reminder") instead of parent-relative paths.' }] }],
     'prettier/prettier': 'error',
   },
 };

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,13 @@
 [tools]
 node = "22.17.1"
 
+[env]
+# The electron package is only used for its TypeScript types
+# (see src/plugin/ui/util.ts); skip the ~100MB binary download.
+# electron's install.js only honors this bare environment variable
+# (an .npmrc key would be exposed as npm_config_* and be ignored).
+ELECTRON_SKIP_BINARY_DOWNLOAD = "1"
+
 # --------------------------------------------------------------------------------
 # Tasks: docs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9420,6 +9420,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-eslint-parser": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "obsidian": "^1.13.1",
         "prettier-plugin-svelte": "^4.1.1",
         "svelte-check": "^4.7.2",
-        "svelte-jester": "^5.0.0",
         "svelte-preprocess": "^6.0.5",
         "ts-jest": "^29.4.11",
         "tslib": "^2.8.1",
@@ -9421,21 +9420,6 @@
         }
       }
     },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/svelte-eslint-parser": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",
@@ -9478,21 +9462,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/svelte-jester": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-jester/-/svelte-jester-5.0.0.tgz",
-      "integrity": "sha512-12UnqprvUClFZHmx8O9exOK5ncHdESMIVG7FM9wRCEBzHbtigsklwKB+Q3AyKPsCrrOS920f9ZbYFk4PO0sEnQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18",
-        "pnpm": "^8.0.0"
-      },
-      "peerDependencies": {
-        "jest": ">= 27",
-        "svelte": ">= 3"
       }
     },
     "node_modules/svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "obsidian": "^1.13.1",
     "prettier-plugin-svelte": "^4.1.1",
     "svelte-check": "^4.7.2",
-    "svelte-jester": "^5.0.0",
     "svelte-preprocess": "^6.0.5",
     "ts-jest": "^29.4.11",
     "tslib": "^2.8.1",

--- a/scripts/check-versions.mjs
+++ b/scripts/check-versions.mjs
@@ -1,0 +1,110 @@
+// Validates that manifest.json / manifest-beta.json / versions.json stay consistent.
+//
+// package.json's version is intentionally excluded: the release flow
+// (.github/workflows/release.yml / release-beta.yml) only ever rewrites
+// manifest.json / manifest-beta.json, so package.json is expected to drift
+// and is not a source of truth for version consistency.
+//
+// NOTE: release.yml / release-beta.yml never touch versions.json (only the
+// local, effectively-unused release.sh does). As a result, in the current
+// repo state versions.json is missing entries for several recent
+// manifest.json/manifest-beta.json versions. Because of that, a missing
+// entry is only a warning here, not a hard failure -- otherwise this check
+// would fail against the current repo state, which the invariant doesn't
+// actually hold for. What IS enforced as a hard failure is: whenever an
+// entry does exist in versions.json for a manifest's version, it must match
+// that manifest's minAppVersion (guards against a typo/manual edit going
+// out of sync).
+
+import console from "node:console";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+let hasError = false;
+
+function fail(message) {
+  console.error(`ERROR: ${message}`);
+  hasError = true;
+}
+
+function readJson(relativePath) {
+  const absolutePath = join(rootDir, relativePath);
+  let raw;
+  try {
+    raw = readFileSync(absolutePath, "utf8");
+  } catch (e) {
+    fail(`Failed to read ${relativePath}: ${e.message}`);
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    fail(`${relativePath} is not valid JSON: ${e.message}`);
+    return null;
+  }
+}
+
+function validateManifest(relativePath, manifest) {
+  if (manifest === null) {
+    return null;
+  }
+  if (typeof manifest.version !== "string" || manifest.version === "") {
+    fail(`${relativePath} is missing a "version" field`);
+  }
+  if (typeof manifest.minAppVersion !== "string" || manifest.minAppVersion === "") {
+    fail(`${relativePath} is missing a "minAppVersion" field`);
+  }
+  return manifest;
+}
+
+function checkVersionsEntry(manifestPath, manifest, versions, { warnOnly }) {
+  if (manifest === null || versions === null) {
+    return;
+  }
+  if (typeof manifest.version !== "string" || typeof manifest.minAppVersion !== "string") {
+    // Already reported by validateManifest().
+    return;
+  }
+
+  const entry = versions[manifest.version];
+  if (entry === undefined) {
+    const message = `versions.json has no entry for ${manifestPath}'s version "${manifest.version}"`;
+    if (warnOnly) {
+      console.warn(`WARNING: ${message}`);
+    } else {
+      fail(message);
+    }
+    return;
+  }
+
+  if (entry !== manifest.minAppVersion) {
+    fail(
+      `versions.json entry for "${manifest.version}" is "${entry}", but ${manifestPath}'s minAppVersion is "${manifest.minAppVersion}"`,
+    );
+  }
+}
+
+const manifest = validateManifest("manifest.json", readJson("manifest.json"));
+const manifestBeta = validateManifest("manifest-beta.json", readJson("manifest-beta.json"));
+const versions = readJson("versions.json");
+
+// manifest.json: see the NOTE above -- a missing entry is a warning, not a
+// failure, because the current release flow doesn't keep versions.json in
+// sync. A mismatched entry is still a hard failure.
+checkVersionsEntry("manifest.json", manifest, versions, { warnOnly: true });
+
+// manifest-beta.json: same treatment, and for the same reason (confirmed by
+// reading the current repo state: versions.json has no entry for the
+// current beta version either).
+checkVersionsEntry("manifest-beta.json", manifestBeta, versions, { warnOnly: true });
+
+if (hasError) {
+  console.error("Version consistency check failed.");
+  process.exit(1);
+}
+
+console.log("Version consistency check passed.");

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,25 @@ export default class ReminderPlugin extends Plugin {
         this.ui.reload(true);
       },
     );
-    this._notificationWorker = new NotificationWorker(this);
+    this._notificationWorker = new NotificationWorker({
+      registerInterval: (id) => this.registerInterval(id),
+      isLayoutReady: () => this.app.workspace.layoutReady,
+      reloadUI: (force) => this.ui.reload(force),
+      isEditing: () => this.ui.isEditing(),
+      showReminder: (reminder) => this.ui.showReminder(reminder),
+      isScanned: () => this.data.scanned.value,
+      markScanned: () => {
+        this.data.scanned.value = true;
+      },
+      saveData: (force) => {
+        this.data.save(force);
+      },
+      reloadRemindersInAllFiles: () =>
+        this.fileSystem.reloadRemindersInAllFiles(),
+      getExpiredReminders: () =>
+        this.reminders.getExpiredReminders(this.settings.reminderTime.value),
+      checkIntervalSec: () => this.settings.reminderCheckIntervalSec.value,
+    });
   }
 
   override async onload() {

--- a/src/model/content.ts
+++ b/src/model/content.ts
@@ -45,7 +45,7 @@ export class Content {
   private async modifyReminderLine(reminder: Reminder, edit: ReminderTodoEdit) {
     const modified = await modifyReminder(this.doc, reminder, edit);
     if (modified) {
-      console.info("Reminder was updated: reminder=%o", reminder);
+      console.debug("Reminder was updated: reminder=%o", reminder);
     } else {
       console.warn(
         "Cannot modify reminder because it's not a reminder todo: reminder=%o",

--- a/src/model/reminder.ts
+++ b/src/model/reminder.ts
@@ -36,8 +36,7 @@ export class Reminder {
   }
 
   public getFileName(): string {
-    const p = this.file.split(/[/\\]/);
-    return p[p.length - 1]!.replace(/^(.*?)(\..+)?$/, "$1");
+    return Reminder.extractFileName(this.file);
   }
 
   static extractFileName(path: string) {
@@ -101,27 +100,21 @@ export class Reminders {
   }
 
   public replaceFile(filePath: string, reminders: Array<Reminder>): boolean {
-    // migrate notificationVisible property
+    // migrate muteNotification property
     const oldReminders = this.fileToReminders.get(filePath);
     if (oldReminders) {
       if (this.equals(oldReminders, reminders)) {
         return false;
       }
-      const reminderToNotificationVisible = new Map<string, boolean>();
+      const keyToMuteNotification = new Map<string, boolean>();
       for (const reminder of oldReminders) {
-        reminderToNotificationVisible.set(
-          reminder.key(),
-          reminder.muteNotification,
-        );
+        keyToMuteNotification.set(reminder.key(), reminder.muteNotification);
       }
       for (const reminder of reminders) {
-        const visible = reminderToNotificationVisible.get(reminder.key());
-        reminderToNotificationVisible.set(
-          reminder.key(),
-          reminder.muteNotification,
-        );
-        if (visible !== undefined) {
-          reminder.muteNotification = visible;
+        const mute = keyToMuteNotification.get(reminder.key());
+        keyToMuteNotification.set(reminder.key(), reminder.muteNotification);
+        if (mute !== undefined) {
+          reminder.muteNotification = mute;
         }
       }
     }
@@ -135,25 +128,14 @@ export class Reminders {
     if (r1.length !== r2.length) {
       return false;
     }
-    this.sort(r1);
-    this.sort(r2);
-    for (const i in r1) {
-      const reminder1 = r1[i];
-      const reminder2 = r2[i];
-      if (reminder1 == null && reminder2 != null) {
-        return false;
-      }
-      if (reminder2 == null && reminder1 != null) {
-        return false;
-      }
-      if (reminder1 == null && reminder2 == null) {
-        continue;
-      }
-      if (!reminder1!.equals(reminder2!)) {
-        return false;
-      }
-    }
-    return true;
+    // Sort copies so we don't mutate the arrays passed in (r1 may be the
+    // array stored inside fileToReminders, and an equality check must not
+    // change stored state).
+    const sorted1 = [...r1];
+    const sorted2 = [...r2];
+    this.sort(sorted1);
+    this.sort(sorted2);
+    return sorted1.every((a, i) => a.equals(sorted2[i]!));
   }
 
   private sortReminders() {
@@ -335,8 +317,6 @@ export function groupReminders(
     );
     overdueGroup.isOverdue = true;
     result.splice(0, 0, new GroupedReminder(overdueGroup, overdueReminders));
-    console.log(overdueGroup);
-    console.log(result);
   }
   return result;
 }

--- a/src/plugin/commands/convert-reminder-time-format.ts
+++ b/src/plugin/commands/convert-reminder-time-format.ts
@@ -1,7 +1,7 @@
 import { OkCancel, showOkCancelDialog } from "plugin/ui/util";
 import type ReminderPlugin from "main";
 import { Content } from "model/content";
-import { openDateTimeFormatChooser } from "../ui/datetime-format-modal";
+import { openDateTimeFormatChooser } from "plugin/ui/datetime-format-modal";
 
 async function convertDateTimeFormat(
   plugin: ReminderPlugin,

--- a/src/plugin/commands/toggle-checklist-status.ts
+++ b/src/plugin/commands/toggle-checklist-status.ts
@@ -22,7 +22,6 @@ async function toggleCheck(
     });
   } else {
     const todo = content.getTodos().find((t) => t.lineIndex === lineNumber);
-    console.log(todo);
     if (!todo) {
       return;
     }

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -1,4 +1,3 @@
-import type ReminderPlugin from "main";
 import { Reference } from "model/ref";
 import { Reminder, Reminders } from "model/reminder";
 import { DateTime } from "model/time";
@@ -11,6 +10,17 @@ interface ReminderData {
   rowNumber: number;
 }
 
+/**
+ * The minimal persistence surface `PluginData` needs. This matches the
+ * signatures of Obsidian's `Plugin.loadData()`/`Plugin.saveData()`, so a
+ * concrete `Plugin` instance is assignable here structurally without
+ * `PluginData` depending on the `obsidian` module.
+ */
+export interface DataStore {
+  loadData(): Promise<unknown>;
+  saveData(data: unknown): Promise<void>;
+}
+
 export class PluginData {
   private restoring = true;
   changed: boolean = false;
@@ -19,7 +29,7 @@ export class PluginData {
   private readonly _settings = new Settings();
 
   constructor(
-    private plugin: ReminderPlugin,
+    private store: DataStore,
     private reminders: Reminders,
   ) {
     this.settings.forEach((setting) => {
@@ -40,7 +50,17 @@ export class PluginData {
 
   async load() {
     console.debug("Load reminder plugin data");
-    const data = await this.plugin.loadData();
+    // `loadData()` returns data of unknown shape (it's whatever was
+    // previously passed to `saveData()`), so this cast is a minimal, trusted
+    // bridge between the untyped persistence API and our persisted data shape.
+    const data = (await this.store.loadData()) as
+      | {
+          scanned: boolean;
+          debug?: boolean;
+          settings?: Record<string, unknown>;
+          reminders?: Record<string, Array<ReminderData>>;
+        }
+      | undefined;
     if (!data) {
       this.scanned.value = false;
       return;
@@ -50,17 +70,14 @@ export class PluginData {
       this.debug.value = data.debug;
     }
 
-    // `loadData()` returns data of unknown shape (it's whatever was
-    // previously passed to `saveData()`), so this cast is a minimal, trusted
-    // bridge between Obsidian's untyped persistence API and our settings model.
-    const loadedSettings = data.settings as Record<string, unknown> | undefined;
     this.settings.forEach((setting) => {
-      setting.load(loadedSettings);
+      setting.load(data.settings);
     });
 
-    if (data.reminders) {
-      Object.keys(data.reminders).forEach((filePath) => {
-        const remindersInFile = data.reminders[filePath] as Array<ReminderData>;
+    const remindersData = data.reminders;
+    if (remindersData) {
+      Object.keys(remindersData).forEach((filePath) => {
+        const remindersInFile = remindersData[filePath];
         if (!remindersInFile) {
           return;
         }
@@ -106,7 +123,7 @@ export class PluginData {
     this.settings.forEach((setting) => {
       setting.store(settings);
     });
-    await this.plugin.saveData({
+    await this.store.saveData({
       scanned: this.scanned.value,
       reminders: remindersData,
       debug: this.debug.value,

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -3,6 +3,7 @@ import { Reference } from "model/ref";
 import { Reminder, Reminders } from "model/reminder";
 import { DateTime } from "model/time";
 import { Settings, TAG_RESCAN } from "plugin/settings";
+import type { SettingModel } from "plugin/settings/helper";
 
 interface ReminderData {
   title: string;
@@ -22,7 +23,10 @@ export class PluginData {
     private reminders: Reminders,
   ) {
     this.settings.forEach((setting) => {
-      setting.rawValue.onChanged(() => {
+      // `setting` is type-erased to `SettingModelBase` here; `rawValue.onChanged`
+      // only registers a listener and doesn't use the raw value type, so
+      // widening to `SettingModel<unknown, unknown>` to reach `rawValue` is safe.
+      (setting as SettingModel<unknown, unknown>).rawValue.onChanged(() => {
         if (this.restoring) {
           return;
         }
@@ -46,7 +50,10 @@ export class PluginData {
       this.debug.value = data.debug;
     }
 
-    const loadedSettings = data.settings;
+    // `loadData()` returns data of unknown shape (it's whatever was
+    // previously passed to `saveData()`), so this cast is a minimal, trusted
+    // bridge between Obsidian's untyped persistence API and our settings model.
+    const loadedSettings = data.settings as Record<string, unknown> | undefined;
     this.settings.forEach((setting) => {
       setting.load(loadedSettings);
     });
@@ -95,7 +102,7 @@ export class PluginData {
         rowNumber: rr.rowNumber,
       }));
     });
-    const settings = {};
+    const settings: Record<string, unknown> = {};
     this.settings.forEach((setting) => {
       setting.store(settings);
     });

--- a/src/plugin/notification-worker.test.ts
+++ b/src/plugin/notification-worker.test.ts
@@ -1,0 +1,116 @@
+import { Reminder } from "model/reminder";
+import { DateTime } from "model/time";
+import { NotificationWorker } from "./notification-worker";
+import type { NotificationWorkerDeps } from "./notification-worker";
+
+function makeReminder(title: string): Reminder {
+  return new Reminder("file.md", title, DateTime.parse("2021-09-08"), 0, false);
+}
+
+function createDeps(
+  overrides: Partial<NotificationWorkerDeps> = {},
+): NotificationWorkerDeps {
+  return {
+    registerInterval: () => {},
+    isLayoutReady: () => true,
+    reloadUI: () => {},
+    isEditing: () => false,
+    showReminder: () => {},
+    isScanned: () => true,
+    markScanned: () => {},
+    saveData: () => {},
+    reloadRemindersInAllFiles: async () => {},
+    getExpiredReminders: () => [],
+    checkIntervalSec: () => 60,
+    ...overrides,
+  };
+}
+
+// `periodicTask` is private; call it directly to test its behavior without
+// going through `startPeriodicTask()`'s `setInterval` scheduling, which is
+// trivial pass-through wiring and not the concern of these tests.
+function callPeriodicTask(worker: NotificationWorker): Promise<void> {
+  return (
+    worker as unknown as { periodicTask(): Promise<void> }
+  ).periodicTask();
+}
+
+describe("NotificationWorker", (): void => {
+  test("shows expired reminders in order via showReminder", async (): Promise<void> => {
+    const r1 = makeReminder("r1");
+    const r2 = makeReminder("r2");
+    const r3 = makeReminder("r3");
+    const shown: Array<Reminder> = [];
+    const deps = createDeps({
+      getExpiredReminders: () => [r1, r2, r3],
+      showReminder: (reminder) => {
+        shown.push(reminder);
+      },
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(shown).toStrictEqual([r1, r2, r3]);
+  });
+
+  test("skips reminders with muteNotification", async (): Promise<void> => {
+    const r1 = makeReminder("r1");
+    r1.muteNotification = true;
+    const r2 = makeReminder("r2");
+    const shown: Array<Reminder> = [];
+    const deps = createDeps({
+      getExpiredReminders: () => [r1, r2],
+      showReminder: (reminder) => {
+        shown.push(reminder);
+      },
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(shown).toStrictEqual([r2]);
+  });
+
+  test("shows nothing while isEditing() is true", async (): Promise<void> => {
+    const showReminder = jest.fn();
+    const getExpiredReminders = jest.fn(() => [makeReminder("r1")]);
+    const deps = createDeps({
+      isEditing: () => true,
+      getExpiredReminders,
+      showReminder,
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(getExpiredReminders).not.toHaveBeenCalled();
+    expect(showReminder).not.toHaveBeenCalled();
+  });
+
+  test("waits for the previous reminder's beingDisplayed flag before showing the next", async (): Promise<void> => {
+    const r1 = makeReminder("r1");
+    const r2 = makeReminder("r2");
+    const events: Array<string> = [];
+    const deps = createDeps({
+      getExpiredReminders: () => [r1, r2],
+      showReminder: (reminder) => {
+        events.push(`show:${reminder.title}`);
+        if (reminder === r1) {
+          // Simulate the modal being displayed, then dismissed shortly
+          // after — the worker must not show `r2` until this clears.
+          r1.beingDisplayed = true;
+          setTimeout(() => {
+            r1.beingDisplayed = false;
+            events.push("cleared");
+          }, 50);
+        }
+      },
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(events).toStrictEqual(["show:r1", "cleared", "show:r2"]);
+  });
+});

--- a/src/plugin/notification-worker.ts
+++ b/src/plugin/notification-worker.ts
@@ -1,8 +1,27 @@
-import type ReminderPlugin from "main";
 import type { Reminder } from "model/reminder";
 
+/**
+ * The minimal set of dependencies `NotificationWorker` needs from the rest
+ * of the plugin. Keeping this narrow (rather than depending on the whole
+ * `ReminderPlugin`) lets this file avoid importing `obsidian` entirely, so
+ * it can be unit-tested like the rest of `model/`.
+ */
+export interface NotificationWorkerDeps {
+  registerInterval(id: number): void;
+  isLayoutReady(): boolean;
+  reloadUI(force: boolean): void;
+  isEditing(): boolean;
+  showReminder(reminder: Reminder): void;
+  isScanned(): boolean;
+  markScanned(): void;
+  saveData(force?: boolean): void;
+  reloadRemindersInAllFiles(): Promise<void>;
+  getExpiredReminders(): Array<Reminder>;
+  checkIntervalSec(): number;
+}
+
 export class NotificationWorker {
-  constructor(private plugin: ReminderPlugin) {}
+  constructor(private deps: NotificationWorkerDeps) {}
 
   startPeriodicTask() {
     let intervalTaskRunning = true;
@@ -12,7 +31,7 @@ export class NotificationWorker {
     });
 
     // Set up the recurring check for reminders.
-    this.plugin.registerInterval(
+    this.deps.registerInterval(
       window.setInterval(() => {
         if (intervalTaskRunning) {
           console.debug(
@@ -24,32 +43,30 @@ export class NotificationWorker {
         this.periodicTask().finally(() => {
           intervalTaskRunning = false;
         });
-      }, this.plugin.settings.reminderCheckIntervalSec.value * 1000),
+      }, this.deps.checkIntervalSec() * 1000),
     );
   }
 
   private async periodicTask(): Promise<void> {
-    this.plugin.ui.reload(false);
+    this.deps.reloadUI(false);
 
-    if (!this.plugin.data.scanned.value) {
-      this.plugin.fileSystem.reloadRemindersInAllFiles().then(() => {
-        this.plugin.data.scanned.value = true;
-        this.plugin.data.save();
+    if (!this.deps.isScanned()) {
+      this.deps.reloadRemindersInAllFiles().then(() => {
+        this.deps.markScanned();
+        this.deps.saveData();
       });
     }
 
-    this.plugin.data.save(false);
+    this.deps.saveData(false);
 
-    if (this.plugin.ui.isEditing()) {
+    if (this.deps.isEditing()) {
       return;
     }
-    const expired = this.plugin.reminders.getExpiredReminders(
-      this.plugin.settings.reminderTime.value,
-    );
+    const expired = this.deps.getExpiredReminders();
 
     let previousReminder: Reminder | undefined = undefined;
     for (const reminder of expired) {
-      if (this.plugin.app.workspace.layoutReady) {
+      if (this.deps.isLayoutReady()) {
         if (reminder.muteNotification) {
           // We don't want to set `previousReminder` in this case as the current
           // reminder won't be shown.
@@ -63,7 +80,7 @@ export class NotificationWorker {
             await this.sleep(100);
           }
         }
-        this.plugin.ui.showReminder(reminder);
+        this.deps.showReminder(reminder);
         previousReminder = reminder;
       }
     }

--- a/src/plugin/notification-worker.ts
+++ b/src/plugin/notification-worker.ts
@@ -15,7 +15,7 @@ export class NotificationWorker {
     this.plugin.registerInterval(
       window.setInterval(() => {
         if (intervalTaskRunning) {
-          console.log(
+          console.debug(
             "Skip reminder interval task because task is already running.",
           );
           return;

--- a/src/plugin/obsidian-hack/command.ts
+++ b/src/plugin/obsidian-hack/command.ts
@@ -11,7 +11,7 @@ class AbstractCommand {
     }
     const checkResult = this.command.checkCallback(true);
     if (checkResult !== undefined && !checkResult) {
-      console.info(
+      console.debug(
         "The command is not available by checking: %o",
         this.command,
       );
@@ -38,7 +38,7 @@ class AbstractCommand {
     }
     const checkResult = this.command.editorCheckCallback(true, editor, view);
     if (checkResult !== undefined && !checkResult) {
-      console.info(
+      console.debug(
         "The editor command is not available by checking: %o",
         this.command,
       );

--- a/src/plugin/obsidian-hack/obsidian-debug-mobile.ts
+++ b/src/plugin/obsidian-hack/obsidian-debug-mobile.ts
@@ -1,4 +1,7 @@
 // Copied from: https://gist.github.com/liamcain/3f21f1ee820cb30f18050d2f3ad85f3f
+// This file intentionally reassigns the global console methods to redirect
+// mobile debug output to a log file, so the no-console rule is disabled here.
+/* eslint-disable no-console */
 import { Platform, Plugin } from "obsidian";
 
 // Call this method inside your plugin's

--- a/src/plugin/settings/helper.ts
+++ b/src/plugin/settings/helper.ts
@@ -28,13 +28,13 @@ class SettingContext {
   public name?: string;
   public desc?: string;
   public tags: Array<string> = [];
-  public settingModel?: SettingModel<any, any>;
+  public settingModel?: SettingModelBase;
   anyValueChanged?: AnyValueChanged;
 
   constructor(private _settingRegistry: SettingRegistry) {}
 
   init(
-    settingModel: SettingModel<any, any>,
+    settingModel: SettingModelBase,
     setting: Setting,
     containerEl: HTMLElement,
   ) {
@@ -104,7 +104,11 @@ class SettingContext {
   }
 
   booleanValue() {
-    return this.settingModel!.value as boolean;
+    // `settingModel` is type-erased to `SettingModelBase` here, but
+    // `booleanValue()` is only ever called for toggle (boolean) settings,
+    // so casting back to a concrete `SettingModel` to read `value` is safe.
+    return (this.settingModel! as SettingModel<unknown, unknown>)
+      .value as boolean;
   }
 
   isInitialized() {
@@ -194,7 +198,7 @@ abstract class AbstractSettingModelBuilder<R> {
 
   protected buildSettingModel<E>(
     serde: Serde<R, E>,
-    initializer: SettingInitilizer<R>,
+    initializer: SettingInitializer<R>,
   ) {
     return new SettingModelImpl(
       this.context,
@@ -202,6 +206,25 @@ abstract class AbstractSettingModelBuilder<R> {
       this.initValue,
       initializer,
     );
+  }
+
+  /**
+   * Wires the shared placeholder/value/onChange behavior for a text-like
+   * component (`TextComponent` or `TextAreaComponent`). Callers supply only
+   * their own parse/validate logic via `onChange`.
+   */
+  protected wireTextComponent(
+    text: AbstractTextComponent<HTMLInputElement | HTMLTextAreaElement>,
+    placeHolder: string,
+    initialValue: string,
+    onChange: (value: string) => void,
+  ): void {
+    text
+      .setPlaceholder(placeHolder)
+      .setValue(initialValue)
+      .onChange(async (value) => {
+        onChange(value);
+      });
   }
 }
 
@@ -223,11 +246,14 @@ class TextSettingModelBuilder extends AbstractSettingModelBuilder<string> {
 
   build<E>(serde: Serde<string, E>): SettingModel<string, E> {
     return this.buildSettingModel(serde, ({ setting, rawValue, context }) => {
-      const initText = (text: AbstractTextComponent<any>) => {
-        text
-          .setPlaceholder(this._placeHolder ?? "")
-          .setValue(rawValue.value)
-          .onChange(async (value) => {
+      const initText = (
+        text: AbstractTextComponent<HTMLInputElement | HTMLTextAreaElement>,
+      ) => {
+        this.wireTextComponent(
+          text,
+          this._placeHolder ?? "",
+          rawValue.value,
+          (value) => {
             try {
               serde.unmarshal(value);
               rawValue.value = value;
@@ -240,7 +266,8 @@ class TextSettingModelBuilder extends AbstractSettingModelBuilder<string> {
                 context.setValidationError(e);
               }
             }
-          });
+          },
+        );
       };
       if (this.longText) {
         setting.addTextArea((textarea) => {
@@ -269,11 +296,12 @@ class NumberSettingModelBuilder extends AbstractSettingModelBuilder<number> {
 
   build<E>(serde: Serde<number, E>): SettingModel<number, E> {
     return this.buildSettingModel(serde, ({ setting, rawValue, context }) => {
-      const initText = (text: AbstractTextComponent<any>) => {
-        text
-          .setPlaceholder(this._placeHolder ?? "")
-          .setValue(rawValue.value.toString())
-          .onChange(async (value) => {
+      setting.addText((text) => {
+        this.wireTextComponent(
+          text,
+          this._placeHolder ?? "",
+          rawValue.value.toString(),
+          (value) => {
             const n = parseInt(value, 10);
             if (Number.isNaN(n)) {
               context.setValidationError("Please enter a valid number.");
@@ -282,10 +310,8 @@ class NumberSettingModelBuilder extends AbstractSettingModelBuilder<number> {
             context.setValidationError(null);
             rawValue.value = n;
             this.onValueChange();
-          });
-      };
-      setting.addText((textarea) => {
-        initText(textarea);
+          },
+        );
       });
     });
   }
@@ -345,21 +371,29 @@ class DropdownSettingModelBuilder extends AbstractSettingModelBuilder<string> {
   }
 }
 
-export interface SettingModel<R, E> extends ReadOnlyReference<E> {
-  rawValue: Reference<R>;
-
+/**
+ * Type-erased operations common to every `SettingModel<R, E>`, independent of
+ * its raw/external value types. Used wherever settings of different `R`/`E`
+ * need to be handled uniformly (e.g. groups, registries, iteration).
+ */
+export interface SettingModelBase {
   readonly key: string;
 
   createSetting(containerEl: HTMLElement): Setting;
 
-  load(settings: any): void;
+  load(settings: Record<string, unknown> | undefined): void;
 
-  store(settings: any): void;
+  store(settings: Record<string, unknown>): void;
 
   hasTag(tag: string): boolean;
 }
 
-type SettingInitilizer<R> = ({
+export interface SettingModel<R, E>
+  extends SettingModelBase, ReadOnlyReference<E> {
+  rawValue: Reference<R>;
+}
+
+type SettingInitializer<R> = ({
   setting,
   rawValue,
   context,
@@ -376,7 +410,7 @@ class SettingModelImpl<R, E> implements SettingModel<R, E> {
     private context: SettingContext,
     private serde: Serde<R, E>,
     initRawValue: R,
-    private settingInitializer: SettingInitilizer<R>,
+    private settingInitializer: SettingInitializer<R>,
   ) {
     this.rawValue = new Reference(initRawValue);
     if (context.key == null) {
@@ -405,17 +439,19 @@ class SettingModelImpl<R, E> implements SettingModel<R, E> {
     return this.context.key!;
   }
 
-  load(settings: any): void {
+  load(settings: Record<string, unknown> | undefined): void {
     if (settings === undefined) {
       return;
     }
     const newValue = settings[this.key];
     if (newValue !== undefined) {
-      this.rawValue.value = newValue;
+      // Persisted values are trusted to already match the shape they were
+      // stored in by `store()`, so this cast back to `R` is safe.
+      this.rawValue.value = newValue as R;
     }
   }
 
-  store(settings: any): void {
+  store(settings: Record<string, unknown>): void {
     settings[this.key] = this.rawValue.value;
   }
 
@@ -425,10 +461,10 @@ class SettingModelImpl<R, E> implements SettingModel<R, E> {
 }
 
 export class SettingGroup {
-  public settings: Array<SettingModel<any, any>> = [];
+  public settings: Array<SettingModelBase> = [];
   constructor(public name: string) {}
 
-  addSettings(...settingModels: Array<SettingModel<any, any>>) {
+  addSettings(...settingModels: Array<SettingModelBase>) {
     this.settings.push(...settingModels);
   }
 }
@@ -458,7 +494,7 @@ export class SettingTabModel {
     this.registry.forEach((context) => context.update());
   }
 
-  public forEach(consumer: (setting: SettingModel<any, any>) => void) {
+  public forEach(consumer: (setting: SettingModelBase) => void) {
     this.groups.forEach((group) => {
       group.settings.forEach((setting) => {
         consumer(setting);

--- a/src/plugin/settings/helper.ts
+++ b/src/plugin/settings/helper.ts
@@ -72,7 +72,7 @@ class SettingContext {
       el.style.display = "none";
     } else {
       el.style.display = "block";
-      el.innerHTML = text;
+      el.textContent = text;
     }
   }
 

--- a/src/plugin/settings/helper.ts
+++ b/src/plugin/settings/helper.ts
@@ -274,18 +274,14 @@ class NumberSettingModelBuilder extends AbstractSettingModelBuilder<number> {
           .setPlaceholder(this._placeHolder ?? "")
           .setValue(rawValue.value.toString())
           .onChange(async (value) => {
-            try {
-              const n = parseInt(value);
-              rawValue.value = n;
-              context.setValidationError(null);
-              this.onValueChange();
-            } catch (e) {
-              if (e instanceof Error) {
-                context.setValidationError(e.message);
-              } else if (typeof e === "string") {
-                context.setValidationError(e);
-              }
+            const n = parseInt(value, 10);
+            if (Number.isNaN(n)) {
+              context.setValidationError("Please enter a valid number.");
+              return;
             }
+            context.setValidationError(null);
+            rawValue.value = n;
+            this.onValueChange();
           });
       };
       setting.addText((textarea) => {
@@ -505,9 +501,15 @@ export class ReminderFormatTypeSerde implements Serde<
   unmarshal(rawValue: string): ReminderFormatType {
     const format = ReminderFormatTypes.find(
       (format) => format.name === rawValue,
-    )!;
-    // TODO return undefined when it is not found
-    return format;
+    );
+    if (format !== undefined) {
+      return format;
+    }
+    console.warn(
+      `Unknown reminder format: ${rawValue}. Falling back to the default format.`,
+    );
+    // ReminderFormatTypes is guaranteed to be non-empty.
+    return ReminderFormatTypes[0]!;
   }
   marshal(value: ReminderFormatType): string {
     return value.name;

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -20,7 +20,7 @@ import {
   SettingTabModel,
   TimeSerde,
 } from "./helper";
-import type { SettingModel } from "./helper";
+import type { SettingModel, SettingModelBase } from "./helper";
 
 export const TAG_RESCAN = "re-scan";
 
@@ -346,7 +346,7 @@ export class Settings {
     setReminderFormatConfig(config);
   }
 
-  public forEach(consumer: (setting: SettingModel<any, any>) => void) {
+  public forEach(consumer: (setting: SettingModelBase) => void) {
     this.settings.forEach(consumer);
   }
 }

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -140,7 +140,7 @@ export class ReminderPluginUI {
   private async openReminderFile(reminder: Reminder) {
     const leaf = this.plugin.app.workspace.getLeaf(false);
 
-    console.log("Open reminder: ", reminder);
+    console.debug("Open reminder: ", reminder);
     const file = this.plugin.app.vault.getAbstractFileByPath(reminder.file);
     if (!(file instanceof TFile)) {
       console.error("Cannot open file because it isn't a TFile: %o", file);
@@ -170,26 +170,26 @@ export class ReminderPluginUI {
     this.showReminderModal(
       reminder,
       (time) => {
-        console.info("Remind me later: time=%o", time);
+        console.debug("Remind me later: time=%o", time);
         reminder.time = time;
         reminder.muteNotification = false;
         this.plugin.fileSystem.updateReminder(reminder, false);
         this.plugin.data.save(true);
       },
       () => {
-        console.info("done");
+        console.debug("done");
         reminder.muteNotification = false;
         this.plugin.fileSystem.updateReminder(reminder, true);
         this.plugin.reminders.removeReminder(reminder);
         this.plugin.data.save(true);
       },
       () => {
-        console.info("Mute");
+        console.debug("Mute");
         reminder.muteNotification = true;
         this.reload(true);
       },
       () => {
-        console.info("Open");
+        console.debug("Open");
         this.openReminderFile(reminder);
       },
     );

--- a/src/plugin/ui/reminder-list.ts
+++ b/src/plugin/ui/reminder-list.ts
@@ -1,7 +1,7 @@
 import { ItemView, TFile, View, WorkspaceLeaf } from "obsidian";
 import ReminderListView from "ui/ReminderList.svelte";
 import type ReminderPlugin from "main";
-import { Reminder, groupReminders } from "../../model/reminder";
+import { Reminder, groupReminders } from "model/reminder";
 import { VIEW_TYPE_REMINDER_LIST } from "./constants";
 
 class ReminderListItemView extends ItemView {

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -1,9 +1,8 @@
 import type { ReadOnlyReference } from "model/ref";
-import type { DateTime } from "model/time";
+import type { Reminder } from "model/reminder";
+import type { DateTime, Later } from "model/time";
 import { App, Modal } from "obsidian";
 import ReminderView from "ui/Reminder.svelte";
-import type { Reminder } from "../../model/reminder";
-import type { Later } from "../../model/time";
 const electron = window.require ? window.require("electron") : undefined;
 
 export class ReminderModal {

--- a/src/ui/DateTimeChooser.svelte
+++ b/src/ui/DateTimeChooser.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
   import moment from "moment";
-  import type { Reminders } from "../model/reminder";
-  import { DateTime } from "../model/time";
+  import type { Reminders } from "model/reminder";
+  import { DateTime } from "model/time";
   import CalendarView from "./Calendar.svelte";
   import TimePicker from "./TimePicker.svelte";
   import ReminderListByDate from "./ReminderListByDate.svelte";

--- a/src/ui/Reminder.svelte
+++ b/src/ui/Reminder.svelte
@@ -1,7 +1,7 @@
 <script lang="typescript">
   import { onMount, tick } from "svelte";
-  import type { Reminder } from "../model/reminder";
-  import type { DateTime, Later } from "../model/time";
+  import type { Reminder } from "model/reminder";
+  import type { DateTime, Later } from "model/time";
   import IconText from "./IconText.svelte";
   import Markdown from "./Markdown.svelte";
 

--- a/src/ui/ReminderList.svelte
+++ b/src/ui/ReminderList.svelte
@@ -1,5 +1,5 @@
 <script lang="typescript">
-  import type { GroupedReminder, Reminder } from "../model/reminder";
+  import type { GroupedReminder, Reminder } from "model/reminder";
   import ReminderListByDate from "./ReminderListByDate.svelte";
 
   export let groups: Array<GroupedReminder>;

--- a/src/ui/ReminderListByDate.svelte
+++ b/src/ui/ReminderListByDate.svelte
@@ -1,6 +1,6 @@
 <script lang="typescript">
-  import type { DateTime } from "../model/time";
-  import type { Reminder } from "../model/reminder";
+  import type { DateTime } from "model/time";
+  import type { Reminder } from "model/reminder";
   import Markdown from "./Markdown.svelte";
 
   export let reminders: Array<Reminder>;


### PR DESCRIPTION
## Summary

A batch of maintainability improvements, ordered from quick wins to structural cleanups. All changes are behavior-preserving except for the explicitly listed bug fixes.

### CI
- **Enforce type checks in PR CI**: `tsc --noEmit` and `svelte-check` previously ran under `continue-on-error` and never failed PRs. They now run as a dedicated enforced step (ESLint keeps the reviewdog annotation flow).
- **Version consistency check**: new `scripts/check-versions.mjs` validates manifest.json / manifest-beta.json and their minAppVersion mapping in versions.json (missing entries warn since the release workflows don't update versions.json today; mismatches fail).

### Bug fixes
- Number settings silently stored `NaN` for invalid input (`parseInt` never throws, so the try/catch was dead code); now validated with an error message.
- `ReminderFormatTypeSerde.unmarshal()` returned `undefined` disguised by a non-null assertion for unknown format names; now warns and falls back to the default format.
- `Reminders.equals()` sorted its argument arrays in place, mutating the array stored in `fileToReminders`; now sorts copies.
- Setting validation/info messages were rendered via `innerHTML`; switched to `textContent` (all call sites pass plain text).

### Lint
- Enable `no-console` (allowing `warn`/`error`/`debug`) and remove leftover debug `console.log` output (including two in `groupReminders()` that fired on every list render).
- Enable `no-restricted-imports` to forbid parent-relative imports and rewrite existing ones to the src-rooted style documented in `.claude/rules/coding-style.md`.

### Refactoring
- **Settings DSL type safety**: removed every `any` from `src/plugin/settings/` (18 → 0) by typing `load`/`store` as `Record<string, unknown>` and introducing a type-erased `SettingModelBase` for heterogeneous collections; deduplicated the Text/Number builder wiring.
- **Narrow dependency injection**: `PluginData` now depends on a minimal `DataStore` interface and `NotificationWorker` on an explicit `NotificationWorkerDeps` object. `NotificationWorker` no longer imports `obsidian`, enabling 4 new unit tests (suite: 45 → 49 tests).

### Dependencies
- Removed unused `svelte-jester` (never registered in jest's transform).
- Skip the ~100MB Electron binary download via `ELECTRON_SKIP_BINARY_DOWNLOAD=1` in `mise.toml` `[env]` and workflow env. Note: an `.npmrc` key does not work for this — npm exposes config to install scripts only as `npm_config_*`, while electron's `install.js` checks the bare variable.

## Test plan

- [x] `npm run lint` (eslint + tsc + svelte-check): 0 errors
- [x] `npx jest`: 49/49 tests pass (4 new NotificationWorker tests)
- [x] `npm run build` (production): succeeds
- [x] `node scripts/check-versions.mjs`: passes (2 warn-only findings about versions.json entries, expected)
- [x] Manual check of the settings tab in Obsidian (validation/info message rendering after the textContent change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
