### PR TITLE
ci: auto-close PRs left awaiting author response

### DIFF
--- a/.github/workflows/awaiting-response.yml
+++ b/.github/workflows/awaiting-response.yml
@@ -21,7 +21,7 @@ jobs:
       (github.event_name == 'pull_request_target' &&
        github.event.sender.login == github.event.pull_request.user.login)
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const issue_number =

--- a/.github/workflows/awaiting-response.yml
+++ b/.github/workflows/awaiting-response.yml
@@ -1,0 +1,39 @@
+name: Remove awaiting-response label on author activity
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    # Run only when the PR author themselves commented on or pushed to the PR.
+    if: >
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.comment.user.login == github.event.issue.user.login) ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.sender.login == github.event.pull_request.user.login)
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number =
+              context.payload.issue?.number ?? context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                name: "awaiting-response",
+              });
+            } catch (error) {
+              // 404 simply means the label was not set; nothing to do.
+              if (error.status !== 404) throw error;
+            }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # Only PRs explicitly labeled by a maintainer are subject to auto-close.
           any-of-pr-labels: awaiting-response

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,19 @@ on:
   schedule:
     - cron: "0 1 * * *"
   workflow_dispatch:
+    inputs:
+      debug-only:
+        description: "Dry run: log what would happen without commenting, labeling, or closing"
+        type: boolean
+        default: true
+      days-before-stale:
+        description: "Override days before marking stale (for testing)"
+        type: number
+        default: 30
+      days-before-close:
+        description: "Override days before closing after stale (for testing)"
+        type: number
+        default: 7
 
 permissions:
   issues: write
@@ -17,8 +30,10 @@ jobs:
         with:
           # Only PRs explicitly labeled by a maintainer are subject to auto-close.
           any-of-pr-labels: awaiting-response
-          days-before-stale: 30
-          days-before-close: 7
+          # Manual runs are dry runs by default; scheduled runs always act.
+          debug-only: ${{ inputs.debug-only == true }}
+          days-before-stale: ${{ inputs.days-before-stale || 30 }}
+          days-before-close: ${{ inputs.days-before-close || 7 }}
           # Issues are out of scope for now.
           days-before-issue-stale: -1
           days-before-issue-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: Close stale awaiting-response PRs
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Only PRs explicitly labeled by a maintainer are subject to auto-close.
+          any-of-pr-labels: awaiting-response
+          days-before-stale: 30
+          days-before-close: 7
+          # Issues are out of scope for now.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          exempt-draft-pr: true
+          exempt-pr-labels: pinned
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has been marked as stale because it has been
+            awaiting a response from the author for 30 days. It will be closed
+            in 7 days if there is no further activity. If you are still working
+            on this, just leave a comment or push a commit — that resets the
+            timer.
+          close-pr-message: >
+            Closing this pull request because there was no response from the
+            author after the stale notice. Thank you for the contribution — if
+            you would like to continue, feel free to reopen it or submit a new
+            pull request against the latest master.


### PR DESCRIPTION
## Summary

Adds an automated lifecycle for PRs that are waiting on their author, so review-requested PRs no longer linger open forever.

- **`.github/workflows/stale.yml`** — daily [actions/stale](https://github.com/actions/stale) run, scoped strictly to PRs carrying the `awaiting-response` label (applied manually by a maintainer when requesting changes). After **30 days** of inactivity it posts a warning comment and adds the `stale` label; after **7 more days** of silence the PR is closed with a friendly message inviting a reopen/resubmission. Draft PRs and PRs labeled `pinned` are exempt. Issues are out of scope (`days-before-issue-stale: -1`).
- **`.github/workflows/awaiting-response.yml`** — removes the `awaiting-response` label as soon as the PR author comments (`issue_comment`) or pushes (`pull_request_target: synchronize`), so a PR that has been answered can never be auto-closed.

## Design notes

- Auto-close applies **only** to labeled PRs — PRs waiting on maintainer review are never touched.
- Two-stage (warn → grace period → close) instead of closing silently at day 30; total ≈ 37 days.
- Any activity on a stale PR removes the `stale` label and resets the timer (actions/stale default).
- The `awaiting-response`, `stale`, and `pinned` labels have been created in the repository.

## Verification

- Both workflow files pass `actionlint` with no warnings.
- After merging, the stale workflow can be smoke-tested via `workflow_dispatch` (it is a no-op while no PR has been labeled long enough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
