### PR TITLE
Fix four bugs with identified root causes (#253, #190/#176, #30, #169)

### DIFF
--- a/src/model/format/reminder-kanban-plugin.test.ts
+++ b/src/model/format/reminder-kanban-plugin.test.ts
@@ -70,6 +70,28 @@ describe("KanbanDateTimeFormat", (): void => {
       expect(res.time).toBe(undefined);
     }
   });
+  test("split - reflects setting changes after construction", (): void => {
+    // The Kanban plugin's settings are read lazily, so toggling
+    // "link date to daily note" must be reflected without recreating the
+    // format instance (https://github.com/uphy/obsidian-reminder/issues/30).
+    const setting = {
+      dateTrigger: "@",
+      dateFormat: "YYYY-MM-DD",
+      timeTrigger: "@@",
+      timeFormat: "HH:mm",
+      linkDateToDailyNote: false,
+    };
+    const sut = new KanbanDateTimeFormat(setting);
+    expect(sut.split("a b c @{2021-09-12}").time!.toString()).toBe(
+      "2021-09-12",
+    );
+    expect(sut.split("a b c @[[2021-09-12]]").time).toBe(undefined);
+
+    setting.linkDateToDailyNote = true;
+    const res = sut.split("a b c @[[2021-09-12]]");
+    expect(res.title).toBe("a b c");
+    expect(res.time!.toString()).toBe("2021-09-12");
+  });
   test("split - with page link", (): void => {
     const sut = new KanbanDateTimeFormat({
       dateTrigger: "@",

--- a/src/model/format/reminder-kanban-plugin.ts
+++ b/src/model/format/reminder-kanban-plugin.ts
@@ -68,19 +68,27 @@ export class KanbanDateTimeFormat {
     kanbanSetting,
   );
 
-  private dateRegExp: RegExp;
-  private timeRegExp: RegExp;
+  constructor(private setting: KanbanSettingType) {}
 
-  constructor(private setting: KanbanSettingType) {
-    let dateRegExpStr: string;
-    if (setting.linkDateToDailyNote) {
-      dateRegExpStr = `${escapeRegExpChars(this.setting.dateTrigger)}\\[\\[(?<date>.+?)\\]\\]`;
-    } else {
-      dateRegExpStr = `${escapeRegExpChars(this.setting.dateTrigger)}\\{(?<date>.+?)\\}`;
+  // The Kanban plugin's settings are not available yet when this module is
+  // loaded (`KanbanDateTimeFormat.instance` is created at import time) and
+  // can change at any time afterwards, so the regular expressions must be
+  // built from the current settings on every use.
+  private get dateRegExp(): RegExp {
+    if (this.setting.linkDateToDailyNote) {
+      return new RegExp(
+        `${escapeRegExpChars(this.setting.dateTrigger)}\\[\\[(?<date>.+?)\\]\\]`,
+      );
     }
-    const timeRegExpStr = `${escapeRegExpChars(this.setting.timeTrigger)}\\{(?<time>.+?)\\}`;
-    this.dateRegExp = new RegExp(dateRegExpStr);
-    this.timeRegExp = new RegExp(timeRegExpStr);
+    return new RegExp(
+      `${escapeRegExpChars(this.setting.dateTrigger)}\\{(?<date>.+?)\\}`,
+    );
+  }
+
+  private get timeRegExp(): RegExp {
+    return new RegExp(
+      `${escapeRegExpChars(this.setting.timeTrigger)}\\{(?<time>.+?)\\}`,
+    );
   }
 
   format(time: DateTime): string {
@@ -104,18 +112,20 @@ export class KanbanDateTimeFormat {
     let date: string;
     let time: string | undefined;
 
-    const dateMatch = this.dateRegExp.exec(text);
+    const dateRegExp = this.dateRegExp;
+    const dateMatch = dateRegExp.exec(text);
     if (dateMatch) {
       date = dateMatch.groups!["date"]!;
-      text = text.replace(this.dateRegExp, "");
+      text = text.replace(dateRegExp, "");
     } else {
       return { title: originalText };
     }
 
-    const timeMatch = this.timeRegExp.exec(text);
+    const timeRegExp = this.timeRegExp;
+    const timeMatch = timeRegExp.exec(text);
     if (timeMatch) {
       time = timeMatch.groups!["time"]!;
-      text = text.replace(this.timeRegExp, "");
+      text = text.replace(timeRegExp, "");
     }
     const title = text.trim();
 

--- a/src/model/format/reminder-tasks-plugin.test.ts
+++ b/src/model/format/reminder-tasks-plugin.test.ts
@@ -19,6 +19,15 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.getTime()!.toString()).toBe("2021-09-08");
     expect(parsed.getDoneDate()!.toString()).toBe("2021-08-31");
   });
+  test("getTitle() - remove tags", (): void => {
+    const parse = (line: string) =>
+      TasksPluginReminderModel.parse(line, false, true);
+    expect(parse("Task1 #task 📅 2021-09-08").getTitle()).toBe("Task1");
+    // nested tag
+    expect(parse("Task1 #task/sub 📅 2021-09-08").getTitle()).toBe("Task1");
+    // non-ASCII tag (https://github.com/uphy/obsidian-reminder/issues/169)
+    expect(parse("Task1 #zokjfkdsaób 📅 2021-09-08").getTitle()).toBe("Task1");
+  });
   test("setTitle()", (): void => {
     const parsed = TasksPluginReminderModel.parse(
       "this is a title 🔁 every hour 📅 2021-09-08 ✅ 2021-08-31",

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -11,7 +11,9 @@ import type { ReminderEdit, ReminderModel } from "./reminder-base";
 import { Symbol, Tokens, splitBySymbol } from "./splitter";
 
 function removeTags(text: string): string {
-  return text.replace(/#\w+/g, "");
+  // Obsidian tags may contain any letters and digits (including non-ASCII
+  // characters), plus "-", "_" and "/" for nested tags.
+  return text.replace(/#[\p{L}\p{N}\p{M}_/-]+/gu, "").trim();
 }
 export class TasksPluginReminderModel implements ReminderModel {
   private static readonly dateFormat = "YYYY-MM-DD";

--- a/src/plugin/ui/autocomplete.ts
+++ b/src/plugin/ui/autocomplete.ts
@@ -10,6 +10,7 @@ import type { ReminderFormatType } from "model/format";
 import type * as CodeMirror from "codemirror";
 import { showDateTimeChooserModal } from "./date-chooser-modal";
 import { DateTimeChooserView } from "./datetime-chooser";
+import { showReminderInsertionFailureNotice } from "./util";
 
 export interface AutoCompletableEditor {
   getCursor(): EditorPosition;
@@ -101,6 +102,7 @@ export class AutoComplete {
     try {
       const appended = format.appendReminder(line, value)?.insertedLine;
       if (appended == null) {
+        showReminderInsertionFailureNotice();
         console.error(
           "Cannot append reminder time to the line: line=%s, date=%s",
           line,

--- a/src/plugin/ui/editor-extension.ts
+++ b/src/plugin/ui/editor-extension.ts
@@ -4,6 +4,7 @@ import type { Reminders } from "model/reminder";
 import type { App } from "obsidian";
 import type { Settings } from "plugin/settings";
 import { showDateTimeChooserModal } from "./date-chooser-modal";
+import { showReminderInsertionFailureNotice } from "./util";
 
 export function buildCodeMirrorPlugin(
   app: App,
@@ -53,6 +54,7 @@ export function buildCodeMirrorPlugin(
                     triggerStart,
                   );
                   if (reminderInsertion == null) {
+                    showReminderInsertionFailureNotice();
                     console.error(
                       "Cannot append reminder time to the line: line=%s, date=%s",
                       line.text,

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -120,15 +120,22 @@ export class ReminderPluginUI {
     );
   }
 
-  showReminderList() {
-    if (
-      this.plugin.app.workspace.getLeavesOfType(VIEW_TYPE_REMINDER_LIST).length
-    ) {
-      return;
+  async showReminderList() {
+    const workspace = this.plugin.app.workspace;
+    let leaf = workspace.getLeavesOfType(VIEW_TYPE_REMINDER_LIST)[0];
+    if (leaf == null) {
+      const rightLeaf = workspace.getRightLeaf(false);
+      if (rightLeaf == null) {
+        return;
+      }
+      await rightLeaf.setViewState({
+        type: VIEW_TYPE_REMINDER_LIST,
+      });
+      leaf = rightLeaf;
     }
-    this.plugin.app.workspace.getRightLeaf(false)?.setViewState({
-      type: VIEW_TYPE_REMINDER_LIST,
-    });
+    // Without revealing the leaf, the view stays hidden when the right
+    // sidebar is collapsed or another view is on top of it.
+    workspace.revealLeaf(leaf);
   }
 
   private detachReminderList() {

--- a/src/plugin/ui/util.ts
+++ b/src/plugin/ui/util.ts
@@ -1,6 +1,13 @@
 import type Electron from "electron";
+import { Notice } from "obsidian";
 
 const electron = window.require ? window.require("electron") : undefined;
+
+export function showReminderInsertionFailureNotice() {
+  new Notice(
+    'Cannot insert a reminder here.  Reminders can only be added to task lines such as "- [ ] Task".',
+  );
+}
 
 export enum OkCancel {
   OK,


### PR DESCRIPTION
## Summary

Batch fix for four bugs whose root causes were pinpointed during an issue triage pass. One commit per fix.

### 1. \`Show Reminders\` command does nothing visible (#253)

\`ReminderPluginUI.showReminderList()\` returned early when the reminder list leaf already existed, and never called \`revealLeaf()\` for a newly created leaf either. When the right sidebar was collapsed (or another view was on top), the command appeared to do nothing. It now reveals the existing or newly created leaf.

### 2. Calendar popup silently fails on non-task lines (#190, #176; also the feedback gap behind #51, #79, #137)

\`appendReminder()\` returns \`null\` when the current line is not a task line (\`- [ ]\` / \`* [ ]\` / \`+ [ ]\`), and both insertion paths (\`editor-extension.ts\` for Live Preview, \`autocomplete.ts\` for the legacy editor and commands) only logged to the console. Users saw the popup, picked a date, and nothing happened. Both paths now show a \`Notice\` explaining that reminders can only be added to task lines.

### 3. Kanban "link date to daily note" dates never recognized (#30)

\`KanbanDateTimeFormat\` built its date/time regexps once in the constructor, and the singleton is created at module load time — before the Kanban plugin's settings are readable — so \`linkDateToDailyNote\` was effectively always \`false\` for parsing and setting changes required an Obsidian restart. The regexps are now built lazily from the current settings on each use. Covered by a new regression test.

### 4. Non-ASCII tags only partially removed from titles (#169)

\`removeTags()\` used \`/#\w+/g\`, which stops at the first non-ASCII character (e.g. \`#zokjfkdsaób\` left \`ób\` behind). Replaced with a Unicode-aware pattern (\`u\` flag, ES2018 — matches the esbuild target) that also covers nested tags and hyphens. Covered by new regression tests.

## Not included (needs more investigation)

- #108 (Kanban 12-hour time format): the time format string is already read dynamically from the Kanban plugin settings, so the reported misparse is not fully explained by the code — needs reproduction before fixing.
- #141 (tags removed when editing dates): the fix requires changing the tokenizer's core behavior in \`splitter.ts\`; deliberately left out of this low-risk batch.

## Test plan

- \`npm run test\`: 51/51 pass (2 new regression tests)
- \`npm run lint:fix\` (eslint + tsc + svelte-check): clean
- \`npm run build\` (production): succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)