### PR TITLE
docs: replace fullwidth punctuation and zh doc links in VuePress boilerplate

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -2,11 +2,11 @@ const { description } = require('../../package')
 
 module.exports = {
   /**
-   * Ref：https://v1.vuepress.vuejs.org/config/#title
+   * Ref: https://v1.vuepress.vuejs.org/config/#title
    */
   title: 'Obsidian Reminder Plugin',
   /**
-   * Ref：https://v1.vuepress.vuejs.org/config/#description
+   * Ref: https://v1.vuepress.vuejs.org/config/#description
    */
   description: description,
 
@@ -15,7 +15,7 @@ module.exports = {
   /**
    * Extra tags to be injected to the page HTML `<head>`
    *
-   * ref：https://v1.vuepress.vuejs.org/config/#head
+   * ref: https://v1.vuepress.vuejs.org/config/#head
    */
   head: [
     ['meta', { name: 'theme-color', content: '#3eaf7c' }],
@@ -27,7 +27,7 @@ module.exports = {
   /**
    * Theme configuration, here is the default theme configuration for VuePress.
    *
-   * ref：https://v1.vuepress.vuejs.org/theme/default-theme-config.html
+   * ref: https://v1.vuepress.vuejs.org/theme/default-theme-config.html
    */
   themeConfig: {
     repo: '',
@@ -85,7 +85,7 @@ module.exports = {
   },
 
   /**
-   * Apply plugins，ref：https://v1.vuepress.vuejs.org/zh/plugin/
+   * Apply plugins, ref: https://v1.vuepress.vuejs.org/plugin/
    */
   plugins: [
     '@vuepress/plugin-back-to-top',

--- a/docs/src/.vuepress/styles/index.styl
+++ b/docs/src/.vuepress/styles/index.styl
@@ -1,7 +1,7 @@
 /**
  * Custom Styles here.
  *
- * ref：https://v1.vuepress.vuejs.org/config/#index-styl
+ * ref: https://v1.vuepress.vuejs.org/config/#index-styl
  */
 
 .home .hero img

--- a/docs/src/.vuepress/styles/palette.styl
+++ b/docs/src/.vuepress/styles/palette.styl
@@ -1,7 +1,7 @@
 /**
  * Custom palette here.
  *
- * ref：https://v1.vuepress.vuejs.org/zh/config/#palette-styl
+ * ref: https://v1.vuepress.vuejs.org/config/#palette-styl
  */
 
 $accentColor = #3eaf7c


### PR DESCRIPTION
## Summary

A repository-wide language audit found that the only non-English text (outside of intentional locale features) was fullwidth CJK punctuation left over from the VuePress default scaffold. This PR cleans that up:

- Replace fullwidth colon/comma (`：`, `，`) with ASCII `:`/`,` in comments of `docs/src/.vuepress/config.js`, `styles/index.styl`, and `styles/palette.styl` (7 lines).
- Point the two VuePress doc links that referenced the Chinese-language pages (`/zh/`) to their English equivalents.

## Intentionally unchanged

- `src/model/reminder.ts` "JP Style (24h/12h)" date format presets (`YYYY年MM月`, `M月D日 (ddd)`) — functional locale data, not prose.
- `docs/src/setting/README.md` line documenting those preset values.
- Emoji used as Tasks-plugin syntax (🔁 ⏰ 📅).

After the change, a full-repo scan finds no remaining fullwidth characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)