### PR TITLE
Show date/time chooser inline near the cursor in Live Preview

### DIFF
--- a/src/plugin/ui/cm6-datetime-chooser.ts
+++ b/src/plugin/ui/cm6-datetime-chooser.ts
@@ -1,0 +1,185 @@
+import type { EditorView } from "@codemirror/view";
+import type { Reminders } from "model/reminder";
+import type { DateTime } from "model/time";
+import moment from "moment";
+import DateTimeChooser from "ui/DateTimeChooser.svelte";
+
+/**
+ * Inline date/time chooser popup for the CodeMirror 6 (Live Preview) editor.
+ *
+ * This mirrors the CM5-era `DateTimeChooserView` (./datetime-chooser.ts):
+ * a `position: fixed` div holding `ui/DateTimeChooser.svelte`, positioned
+ * near the cursor. The main differences are:
+ * - Positioning uses CM6's `EditorView.coordsAtPos()` instead of CM5's
+ *   `charCoords()`. `coordsAtPos()` already returns viewport-relative
+ *   coordinates, so no offset against `document.body`'s bounding rect is
+ *   needed.
+ * - Keyboard interaction (arrow keys / Enter inside the calendar and time
+ *   picker) is handled by giving the popup real DOM focus, which is picked
+ *   up by the existing `on:keydown` handlers in Calendar.svelte and
+ *   TimePicker.svelte. Escape and clicking outside the popup close it here.
+ * - Focus is returned to the editor when the popup closes, so typing can
+ *   continue seamlessly whether the user picked a date/time or cancelled.
+ */
+/** Minimum gap between the popup and the viewport edges. */
+const VIEWPORT_MARGIN = 8;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export class CM6DateTimeChooserPopup {
+  private view: HTMLElement;
+  private dateTimeChooser?: DateTimeChooser;
+  private resultResolve?: (result: DateTime) => void;
+  private resultReject?: () => void;
+  // The document position the popup is anchored to (right after the trigger).
+  private anchorPos = 0;
+
+  private onDocumentMouseDown = (event: MouseEvent): void => {
+    if (!this.view.contains(event.target as Node)) {
+      this.cancel();
+    }
+  };
+
+  private onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      event.stopPropagation();
+      this.cancel();
+    }
+  };
+
+  // Follow editor scrolling (and window resizes) so the fixed-position popup
+  // stays anchored to the trigger's text position. Reading the layout via
+  // coordsAtPos() is fine here: the restriction only applies inside the CM6
+  // update cycle.
+  private onReposition = (): void => {
+    this.position(this.anchorPos);
+  };
+
+  constructor(
+    private editorView: EditorView,
+    private reminders: Reminders,
+    private timeStep: number,
+  ) {
+    this.view = document.createElement("div");
+    this.view.addClass("date-time-chooser-popup");
+    this.view.style.position = "fixed";
+  }
+
+  /** Show the popup near the given document position and wait for a result. */
+  show(pos: number): Promise<DateTime> {
+    this.anchorPos = pos;
+
+    // Attach the container to the DOM before mounting the Svelte component:
+    // Calendar.svelte's onMount reads `table.clientWidth` to size the footer
+    // slot, which is 0 while the container is detached (that would collapse
+    // the reminder list in the footer to zero width). Positioning in turn
+    // needs the popup's own size, known only after mounting — so keep it
+    // invisible until it has been measured and placed, to avoid a visible
+    // jump.
+    this.view.style.visibility = "hidden";
+    document.body.appendChild(this.view);
+    this.dateTimeChooser = new DateTimeChooser({
+      target: this.view,
+      props: {
+        onSelect: (time: DateTime) => {
+          this.setResult(time);
+          this.hide();
+        },
+        reminders: this.reminders,
+        timeStep: this.timeStep,
+        date: moment(),
+      },
+    });
+    this.position(pos);
+    this.view.style.visibility = "visible";
+
+    document.addEventListener("mousedown", this.onDocumentMouseDown, true);
+    this.view.addEventListener("keydown", this.onKeyDown);
+    this.editorView.scrollDOM.addEventListener("scroll", this.onReposition, {
+      passive: true,
+    });
+    window.addEventListener("resize", this.onReposition, { passive: true });
+
+    // Move real DOM focus into the popup so arrow keys / Enter reach the
+    // calendar's own keydown handling (Calendar.svelte).
+    this.view.querySelector<HTMLElement>(".reminder-calendar")?.focus();
+
+    return new Promise<DateTime>((resolve, reject) => {
+      this.resultResolve = resolve;
+      this.resultReject = reject;
+    });
+  }
+
+  /**
+   * Place the popup at the given document position, kept fully inside the
+   * viewport: preferably below the cursor, flipped above it when it would
+   * overflow the bottom edge, and clamped to the viewport otherwise.
+   */
+  private position(pos: number): void {
+    const coords = this.editorView.coordsAtPos(pos);
+    const editorRect = this.editorView.dom.getBoundingClientRect();
+    const anchorTop = coords?.top ?? editorRect.top;
+    const anchorBottom = coords?.bottom ?? editorRect.top;
+    const anchorLeft = coords?.left ?? editorRect.left;
+
+    const { width, height } = this.view.getBoundingClientRect();
+
+    // Preferred: below the cursor. Flip above when it would overflow the
+    // bottom of the viewport, then clamp into the viewport as a last resort.
+    let top = anchorBottom;
+    if (top + height > window.innerHeight - VIEWPORT_MARGIN) {
+      top = anchorTop - height;
+    }
+    top = clamp(
+      top,
+      VIEWPORT_MARGIN,
+      Math.max(window.innerHeight - height - VIEWPORT_MARGIN, VIEWPORT_MARGIN),
+    );
+    const left = clamp(
+      anchorLeft,
+      VIEWPORT_MARGIN,
+      Math.max(window.innerWidth - width - VIEWPORT_MARGIN, VIEWPORT_MARGIN),
+    );
+
+    this.view.style.top = `${top}px`;
+    this.view.style.left = `${left}px`;
+  }
+
+  /** Close the popup without producing a result (used for Escape/click-outside/destroy). */
+  cancel(): void {
+    this.setResult(null);
+    this.hide();
+  }
+
+  private setResult(result: DateTime | null): void {
+    if (this.resultReject == null || this.resultResolve == null) {
+      return;
+    }
+    if (result === null) {
+      this.resultReject();
+    } else {
+      this.resultResolve(result);
+    }
+    this.resultReject = undefined;
+    this.resultResolve = undefined;
+  }
+
+  private hide(): void {
+    document.removeEventListener("mousedown", this.onDocumentMouseDown, true);
+    this.view.removeEventListener("keydown", this.onKeyDown);
+    this.editorView.scrollDOM.removeEventListener("scroll", this.onReposition);
+    window.removeEventListener("resize", this.onReposition);
+    // The popup is single-use: destroy the Svelte component along with
+    // detaching the container.
+    this.dateTimeChooser?.$destroy();
+    this.dateTimeChooser = undefined;
+    if (this.view.parentNode) {
+      this.view.parentNode.removeChild(this.view);
+    }
+    // Return focus to the editor so typing continues seamlessly.
+    this.editorView.focus();
+  }
+}

--- a/src/plugin/ui/editor-extension.ts
+++ b/src/plugin/ui/editor-extension.ts
@@ -1,8 +1,11 @@
 import { EditorSelection } from "@codemirror/state";
 import { ViewPlugin, ViewUpdate } from "@codemirror/view";
 import type { Reminders } from "model/reminder";
+import type { DateTime } from "model/time";
+import { Platform } from "obsidian";
 import type { App } from "obsidian";
 import type { Settings } from "plugin/settings";
+import { CM6DateTimeChooserPopup } from "./cm6-datetime-chooser";
 import { showDateTimeChooserModal } from "./date-chooser-modal";
 import { showReminderInsertionFailureNotice } from "./util";
 
@@ -13,6 +16,13 @@ export function buildCodeMirrorPlugin(
 ) {
   return ViewPlugin.fromClass(
     class {
+      // The currently open inline popup, if any. Tracked so it can be
+      // cancelled when a new trigger fires or the editor view is destroyed.
+      private activePopup?: CM6DateTimeChooserPopup;
+      // Set by destroy(). Guards the deferred popup opening below so a
+      // popup never opens after the editor view has been torn down.
+      private destroyed = false;
+
       update(update: ViewUpdate) {
         if (!update.docChanged) {
           return;
@@ -26,7 +36,40 @@ export function buildCodeMirrorPlugin(
           const trigger = settings.autoCompleteTrigger.value;
           const timeStep = settings.reminderTimeStep.value;
           if (trigger === text) {
-            showDateTimeChooserModal(app, reminders, timeStep)
+            let result: Promise<DateTime>;
+            if (Platform.isDesktopApp) {
+              // Defer opening the popup out of the CM6 update cycle:
+              // coordsAtPos() (and DOM reads in general) throws
+              // "Reading the editor layout isn't allowed during an update"
+              // when called synchronously inside ViewPlugin.update().
+              result = new Promise<DateTime>((resolve, reject) => {
+                setTimeout(() => {
+                  if (this.destroyed) {
+                    reject();
+                    return;
+                  }
+                  this.activePopup?.cancel();
+                  const popup = new CM6DateTimeChooserPopup(
+                    update.view,
+                    reminders,
+                    timeStep,
+                  );
+                  this.activePopup = popup;
+                  popup
+                    .show(toB)
+                    .finally(() => {
+                      if (this.activePopup === popup) {
+                        this.activePopup = undefined;
+                      }
+                    })
+                    .then(resolve, reject);
+                }, 0);
+              });
+            } else {
+              result = showDateTimeChooserModal(app, reminders, timeStep);
+            }
+
+            result
               .then((value) => {
                 const format = settings.primaryFormat.value.format;
                 try {
@@ -85,6 +128,11 @@ export function buildCodeMirrorPlugin(
               });
           }
         });
+      }
+
+      destroy() {
+        this.destroyed = true;
+        this.activePopup?.cancel();
       }
     },
   );

--- a/src/ui/ReminderListByDate.svelte
+++ b/src/ui/ReminderListByDate.svelte
@@ -5,7 +5,7 @@
 
   export let reminders: Array<Reminder>;
   export let onOpenReminder: (reminder: Reminder) => void = () => {};
-  export let timeToString = (time: DateTime) => time.format("HH:MM");
+  export let timeToString = (time: DateTime) => time.format("HH:mm");
   export let generateLink: (reminder: Reminder) => string = () => "";
 </script>
 


### PR DESCRIPTION
## Summary

In the Live Preview (CodeMirror 6) editor, typing the autocomplete trigger (default `(@`) opened the date/time chooser as a centered modal, while the legacy CM5 editor showed it inline near the cursor. This PR adds `CM6DateTimeChooserPopup`, an inline popup anchored to the cursor, used on desktop; mobile keeps the modal. This is a from-scratch redo of the abandoned draft #123.

## Changes

- **`src/plugin/ui/cm6-datetime-chooser.ts`** (new): inline popup that mounts the existing `ui/DateTimeChooser.svelte` into a fixed-position container (same `date-time-chooser-popup` class as the CM5 version).
  - Positioned via `EditorView.coordsAtPos()`; flips above the cursor when it would overflow the bottom of the viewport and clamps to the viewport otherwise, and repositions on editor scroll / window resize so it stays anchored to the trigger line.
  - The Svelte component is mounted only after the container is attached to the DOM — `Calendar.svelte` sizes its footer slot from `table.clientWidth`, which is 0 while detached (this collapsed the reminder-list titles to zero width).
  - Keyboard support comes from giving the calendar real DOM focus (arrows/Enter/digit input are handled by the existing Svelte components). Escape and click-outside cancel, leaving the trigger text in place, and focus returns to the editor on close.
  - `timeStep` is passed through to the chooser (the CM5 inline popup missed it).
- **`src/plugin/ui/editor-extension.ts`**: on desktop, open the inline popup instead of the modal; mobile is unchanged. The popup is opened via `setTimeout` because CM6 forbids layout reads (`coordsAtPos`) inside `ViewPlugin.update()`; a `destroyed` flag guards the race with view teardown, and an open popup is cancelled when a new trigger fires or the view is destroyed. Trigger detection and the line-rewrite logic are untouched.
- **`src/ui/ReminderListByDate.svelte`**: fix the default time format `HH:MM` → `HH:mm` (`MM` is months in moment, so date-only reminders showed the month in the minutes position, e.g. `00:07` in July). This default is also used by the modal's footer list; the sidebar passes its own formatter and is unaffected.

## Testing

- `eslint` + `tsc --noEmit` + `svelte-check`: 0 errors; full jest suite passes (the change is UI-layer code, which is not unit-testable per repo convention).
- Manually verified in a real vault (Live Preview, desktop): popup appears at the cursor; arrow/Enter/digit-key navigation; Escape and click-outside cancel leaving `(@` intact; selection rewrites the line with the caret after the inserted date; footer reminder list shows titles/filenames with correct times; popup flips above the cursor at the bottom of the window and follows editor scrolling; rapid re-trigger replaces the open popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)