### PR TITLE
Add manual-verify skill and post-coding verification reminder hook

### DIFF
--- a/.claude/hooks/manual-verify-reminder.sh
+++ b/.claude/hooks/manual-verify-reminder.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Stop hook
+#
+# Reminds Claude to run the manual-verify skill (real-vault verification)
+# before finishing a turn that changed TypeScript/Svelte sources. Automated
+# tests only cover src/model/, so anything touching the Obsidian API needs a
+# human check in a running Obsidian.
+#
+# This is a one-shot reminder, not a hard gate: manual verification requires
+# the user's participation (restarting Obsidian, clicking through), and some
+# changes (docs, tests, model-only logic fully covered by unit tests) don't
+# need it. A hash of the changed files' contents is cached in
+# .claude/hooks/.manual-verify-state; once the reminder has fired for a given
+# state, the same state is let through. Any further source edit changes the
+# hash and re-arms the reminder.
+#
+# Reads the Stop hook JSON payload from stdin, e.g.:
+#   {"cwd": "/abs/project/dir", ...}
+#
+# Exit codes:
+#   0 - nothing to remind about, or already reminded for this state
+#   2 - reminder fired; instructions written to stderr
+
+set -uo pipefail
+
+input="$(cat)"
+
+json_field() {
+  local filter="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$input" | jq -r "$filter // empty" 2>/dev/null
+  elif command -v node >/dev/null 2>&1; then
+    NODE_JSON_INPUT="$input" NODE_JSON_FILTER="$filter" node -e '
+      try {
+        const data = JSON.parse(process.env.NODE_JSON_INPUT || "{}");
+        const filter = process.env.NODE_JSON_FILTER;
+        let value;
+        if (filter === ".cwd") {
+          value = data.cwd;
+        }
+        process.stdout.write(value ? String(value) : "");
+      } catch (e) {
+        process.stdout.write("");
+      }
+    ' 2>/dev/null
+  fi
+}
+
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$project_dir" ]; then
+  project_dir="$(json_field '.cwd')"
+fi
+if [ -z "$project_dir" ]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  project_dir="$(cd "$script_dir/../.." && pwd)"
+fi
+
+cd "$project_dir" || exit 0
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Tracked + untracked .ts/.svelte changes (excludes ignored files like main.js).
+changed_files="$(git status --porcelain -- '*.ts' '*.svelte' 2>/dev/null | awk '{print $2}')"
+
+if [ -z "$changed_files" ]; then
+  exit 0
+fi
+
+state_dir=".claude/hooks"
+state_file="$state_dir/.manual-verify-state"
+mkdir -p "$state_dir"
+
+hash_cmd=""
+if command -v shasum >/dev/null 2>&1; then
+  hash_cmd="shasum -a 256"
+elif command -v sha256sum >/dev/null 2>&1; then
+  hash_cmd="sha256sum"
+fi
+
+current_hash=""
+if [ -n "$hash_cmd" ]; then
+  current_hash="$(
+    while IFS= read -r f; do
+      [ -f "$f" ] && cat "$f"
+    done <<<"$changed_files" | $hash_cmd | awk '{print $1}'
+  )"
+fi
+
+last_hash=""
+if [ -f "$state_file" ]; then
+  last_hash="$(cat "$state_file" 2>/dev/null)"
+fi
+
+if [ -n "$current_hash" ] && [ "$current_hash" = "$last_hash" ]; then
+  # Already reminded for exactly this set of changes.
+  exit 0
+fi
+
+if [ -n "$current_hash" ]; then
+  printf '%s' "$current_hash" >"$state_file"
+fi
+
+{
+  echo "Manual verification reminder: this turn ends with uncommitted .ts/.svelte changes."
+  echo ""
+  echo "Automated tests only cover src/model/. If these changes affect runtime behavior"
+  echo "in Obsidian (anything under src/plugin/ or src/ui/, parsing behavior visible in"
+  echo "the vault, etc.), invoke the manual-verify skill now to set up the test vault and"
+  echo "guide the user through verification."
+  echo ""
+  echo "If manual verification is genuinely unnecessary (docs/test-only changes, or"
+  echo "model-layer logic fully covered by unit tests), briefly state that reasoning to"
+  echo "the user and finish. This reminder fires once per change state and will not"
+  echo "block again until the sources change further."
+} >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,11 @@
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/stop-check.sh",
             "timeout": 120
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/manual-verify-reminder.sh",
+            "timeout": 30
           }
         ]
       }

--- a/.claude/skills/manual-verify/SKILL.md
+++ b/.claude/skills/manual-verify/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: manual-verify
+description: Set up the local test vault and guide the user through manual verification of obsidian-reminder changes. Use this whenever a change should be verified in a real Obsidian vault — after implementing a fix or feature, when preparing a PR for review, or when the user says things like "動作確認して", "動作確認を手伝って", "テスト環境を整えて", "vaultで確認したい", or asks how to check that a change actually works. It prepares the vault (plugin symlink, plugin settings, companion plugins, generated test notes with per-fix instructions) and then hands the user a short checklist to execute in Obsidian.
+---
+
+# Manual verification in a test vault
+
+Automated tests only cover `src/model/`; anything touching the Obsidian API must be
+verified by a human in a running Obsidian. This skill prepares everything so that the
+user only has to launch Obsidian and walk through generated test notes.
+
+## Environment-specific configuration
+
+Never hardcode vault paths, plugin directory names, or other machine-specific details
+in this skill, in test notes' front matter, or in any committed file. Read them from
+`CLAUDE.local.md` at the repository root (auto-loaded into context, gitignored).
+Expected entries: test vault path, plugin symlink location, installed companion
+plugins. If `CLAUDE.local.md` is missing or lacks the vault path, ask the user where
+their test vault is and offer to record it in `CLAUDE.local.md` for next time.
+
+## Workflow
+
+### 1. Build the code under verification
+
+Run a production build in the checkout to verify (main repo or a worktree):
+
+```bash
+mise exec -- npm run build
+```
+
+Confirm the change is actually in the artifact before involving the user, e.g.
+`grep -c "<some string unique to the change>" main.js`. The vault loads `main.js`,
+`manifest.json`, and `styles.css` from the plugin directory; all three exist at the
+checkout root after a build.
+
+### 2. Point the vault at the checkout
+
+```bash
+ln -sfn <checkout-path> <vault>/.obsidian/plugins/<plugin-dir>
+```
+
+A git worktree works fine as the target: the hot-reload plugin watches any plugin
+directory containing `.git`, and a worktree's `.git` file satisfies that.
+
+### 3. Prepare plugin settings (the data.json gotcha)
+
+Because of the symlink, the plugin's `data.json` lives at the checkout root (it is
+gitignored). Two rules:
+
+- **Never edit `data.json` while Obsidian is running.** The live plugin periodically
+  saves its in-memory state and will silently overwrite your edits. Stage the desired
+  file in the session scratchpad, ask the user to quit Obsidian, copy it into place,
+  verify the copy, then ask them to relaunch.
+- **Set `"scanned": false` and `"reminders": {}`** in the staged file. This forces a
+  full vault rescan at startup; otherwise test notes created while Obsidian was
+  closed may not be picked up (the plugin has no create-event listener, see #270).
+
+Enable exactly the settings the tests need (e.g. `enableTasksPluginReminderFormat`,
+`enableKanbanPluginReminderFormat`, `removeTagsForTasksPlugin`). Keys can be read
+from an existing `data.json` or `src/plugin/settings/index.ts`.
+
+### 4. Install companion plugins when the change involves interop
+
+For fixes involving the Tasks/Kanban/etc. plugins, install the real plugin into the
+vault (while Obsidian is closed):
+
+```bash
+mkdir -p <vault>/.obsidian/plugins/<plugin-id>
+cd <vault>/.obsidian/plugins/<plugin-id>
+gh release download -R <owner>/<repo> --pattern main.js --pattern manifest.json --pattern styles.css --clobber
+```
+
+Then write the companion plugin's `data.json` with the settings the test requires
+(e.g. Kanban's `"link-date-to-daily-note": true`), and add its plugin id to
+`<vault>/.obsidian/community-plugins.json`.
+
+### 5. Generate test notes
+
+Create one note per fix in a dedicated folder at the vault root (default:
+`reminder-test/`), numbered in the order the user should execute them
+(`1-<short title> (#<issue>).md`, ...). Write the notes in the user's conversation
+language — the user reads them inside Obsidian, so they must be self-contained; the
+user should never need to switch back to the chat mid-test.
+
+Template for each note:
+
+```markdown
+# テスト<N>: <what is being verified> (#<issue>)
+
+**手順**
+
+1. <concrete step>
+2. <concrete step>
+
+**期待結果（修正後）**: <observable outcome>
+**修正前の挙動**: <what the bug looked like, so the user can tell a real pass from a no-op>
+
+<fixture lines the steps operate on, e.g. task lines>
+```
+
+Fixture rules:
+
+- Use **future dates** (a week or more ahead) so reminders show up in the list
+  without immediately firing notification popups during the test session.
+- When a fix changes behavior on valid input, add a regression check to the same
+  note (e.g. "insertion on a proper task line still works").
+
+### 6. Hand the user a checklist
+
+Post a compact message: quit/relaunch timing if settings were staged, the note order,
+and a one-line expected result per note (a table works well). Mention that the first
+launch rescans the vault and may take a few seconds. Ask for OK/NG per item, and for
+NG ask what was observed.
+
+### 7. After verification
+
+- Offer to record the verification results as a PR comment (English, factual, one
+  line per verified fix).
+- Offer cleanup: restore the vault symlink to the main repository checkout (rebuild
+  master first so the vault serves the merged code), remove the worktree/branch.
+  Test notes and companion plugins can stay in the vault for next time — mention it
+  and let the user decide.

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ data.json
 # Claude Code local-only files
 .claude/settings.local.json
 .claude/hooks/.stop-check-state
+.claude/hooks/.manual-verify-state
 .claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ Symlink the dev vault's `.obsidian/plugins/obsidian-reminder-plugin` to this rep
 
 With this set up, running `mise run dev` keeps esbuild's watch build resident, so every time you save a source file it automatically rebuilds and reloads in Obsidian. No manual copying or restarting Obsidian is needed.
 
+Automated tests only cover `src/model/`. After implementing a change that affects runtime behavior in Obsidian (anything under `src/plugin/` or `src/ui/`, or parsing behavior visible in the vault), run the `manual-verify` skill to set up the test vault and walk the user through verification before opening a PR. A Stop hook (`.claude/hooks/manual-verify-reminder.sh`) reminds about this once per change state.
+
 ## Release flow
 
 `release.sh` (a local script that bumps the version and creates a tag, master branch only) rewrites both package.json and manifest.json, but what's actually used in practice is `.github/workflows/release.yml` and `release-beta.yml` (triggered manually via `workflow_dispatch`). These rewrite **only manifest.json**, then handle the commit, tagging, GitHub Release creation, and (for the official release only) the gh-pages deploy of the docs site. **package.json's version is never updated by this flow, so it can drift from manifest.json** (indeed, in this repository package.json=1.1.15 and manifest.json=1.1.21 currently disagree). Treat manifest.json/manifest-beta.json/versions.json as the source of truth for version consistency.


### PR DESCRIPTION
## Summary

Tooling for Claude Code sessions in this repository — no plugin code changes.

### `manual-verify` skill (`.claude/skills/manual-verify/SKILL.md`)

Encodes the manual verification workflow used for #303 and #306: build the checkout under test, point the test vault's plugin symlink at it, stage plugin settings safely (the live plugin overwrites `data.json` while Obsidian runs, and `"scanned": false` is required so new test notes are picked up), install companion plugins (e.g. Kanban) when the change involves interop, generate numbered per-fix test notes with steps / expected result / pre-fix behavior, and hand the user a compact checklist.

Environment-specific details (test vault path, installed companion plugins) are intentionally NOT in the skill — it reads them from the gitignored `CLAUDE.local.md` at the repo root and asks the user if missing.

### Stop hook (`.claude/hooks/manual-verify-reminder.sh`)

Since automated tests only cover `src/model/`, a turn that ends with uncommitted `.ts`/`.svelte` changes now gets a one-shot reminder to run the manual-verify skill (or to state why verification is unnecessary). Same hash-based once-per-change-state design as the existing `stop-check.sh`; any further source edit re-arms it. Registered in `.claude/settings.json` after the static-check hook.

### Docs

One paragraph added to CLAUDE.md (Local development) stating the verification expectation; the hook state file added to `.gitignore`.

## Test plan

- Hook tested manually: fires exit 2 with the reminder on first Stop with changed sources, exits 0 for the same change state, re-arms on further edits; state file is gitignored.
- Skill exercised end-to-end in a real session (verification of #306).

🤖 Generated with [Claude Code](https://claude.com/claude-code)