### PR TITLE
Preserve tags when editing dates in Tasks plugin format

### DIFF
--- a/src/model/format/reminder-tasks-plugin.test.ts
+++ b/src/model/format/reminder-tasks-plugin.test.ts
@@ -78,6 +78,26 @@ describe("TasksPluginReminderLine", (): void => {
       "this is a title 🔁every hour ✅2021-08-31 📅2021-09-08",
     );
   });
+  test("setTime() - tag after due date is preserved (#141)", (): void => {
+    const parsed = TasksPluginReminderModel.parse("Task 📅 2021-09-08 #mytag");
+    parsed.setTime(new DateTime(moment("2021-09-09"), false));
+    expect(parsed.getTime()!.toString()).toBe("2021-09-09");
+    expect(parsed.toMarkdown()).toBe("Task 📅 2021-09-09 #mytag");
+  });
+  test("setTime() - tag between due date and done date is preserved (#141)", (): void => {
+    const parsed = TasksPluginReminderModel.parse(
+      "Task 📅 2021-09-08 #mytag ✅ 2021-08-31",
+    );
+    parsed.setTime(new DateTime(moment("2021-09-09"), false));
+    expect(parsed.getTime()!.toString()).toBe("2021-09-09");
+    expect(parsed.toMarkdown()).toBe("Task 📅 2021-09-09 #mytag ✅ 2021-08-31");
+  });
+  test("setTime() - date without a tag still works (#141 regression guard)", (): void => {
+    const parsed = TasksPluginReminderModel.parse("Task 📅 2021-09-08");
+    parsed.setTime(new DateTime(moment("2021-09-09"), false));
+    expect(parsed.getTime()!.toString()).toBe("2021-09-09");
+    expect(parsed.toMarkdown()).toBe("Task 📅 2021-09-09");
+  });
   test("setTime() - append - no advice", (): void => {
     const parsed = TasksPluginReminderModel.parse("this is a title");
     parsed.setTime(new DateTime(moment("2021-09-08"), false));

--- a/src/model/format/splitter.test.ts
+++ b/src/model/format/splitter.test.ts
@@ -40,6 +40,65 @@ describe("splitBySymbol()", (): void => {
       splitBySymbol("this is a title", symbolOf("📅📆🗓✅🔁")),
     ).toStrictEqual([{ symbol: "", text: "this is a title" }]);
   });
+
+  test("tag after a symbol token becomes its own token (#141)", (): void => {
+    expect(
+      splitBySymbol("Task 📅 2021-09-08 #mytag", symbolOf("📅📆🗓✅🔁")),
+    ).toStrictEqual([
+      { symbol: "", text: "Task " },
+      { symbol: "📅", text: " 2021-09-08 " },
+      { symbol: "", text: "#mytag" },
+    ]);
+  });
+
+  test("tag between two symbol tokens becomes its own token", (): void => {
+    expect(
+      splitBySymbol(
+        "Task 📅 2021-09-08 #mytag ✅ 2021-08-31",
+        symbolOf("📅📆🗓✅🔁"),
+      ),
+    ).toStrictEqual([
+      { symbol: "", text: "Task " },
+      { symbol: "📅", text: " 2021-09-08 " },
+      { symbol: "", text: "#mytag " },
+      { symbol: "✅", text: " 2021-08-31" },
+    ]);
+  });
+
+  test("# inside a word does not split", (): void => {
+    expect(
+      splitBySymbol("Task 📅 2021-09-08 a#b", symbolOf("📅📆🗓✅🔁")),
+    ).toStrictEqual([
+      { symbol: "", text: "Task " },
+      { symbol: "📅", text: " 2021-09-08 a#b" },
+    ]);
+  });
+
+  test("tag in the title (before any symbol) is unaffected", (): void => {
+    expect(
+      splitBySymbol("Task #mytag 📅 2021-09-08", symbolOf("📅📆🗓✅🔁")),
+    ).toStrictEqual([
+      { symbol: "", text: "Task #mytag " },
+      { symbol: "📅", text: " 2021-09-08" },
+    ]);
+  });
+
+  test("round-trip: join() reproduces the original line", (): void => {
+    const symbols = symbolOf("📅📆🗓✅🔁");
+    const lines = [
+      "this is a title #tag1 #tag2 🔁every hour📅2021-09-08 ✅2021-08-31",
+      "this is a title",
+      "Task 📅 2021-09-08 #mytag",
+      "Task 📅 2021-09-08 #mytag ✅ 2021-08-31",
+      "Task 📅 2021-09-08 a#b",
+      "Task #mytag 📅 2021-09-08",
+      "#mytag",
+      "📅#mytag",
+    ];
+    for (const line of lines) {
+      expect(new Tokens(splitBySymbol(line, symbols)).join()).toBe(line);
+    }
+  });
 });
 
 describe("Tokens", (): void => {

--- a/src/model/format/splitter.ts
+++ b/src/model/format/splitter.ts
@@ -210,6 +210,20 @@ export function splitBySymbol(
       currentToken = { symbol: c, text: "" };
       splitted.push(currentToken);
       text = "";
+    } else if (
+      currentToken !== null &&
+      c === "#" &&
+      (text.length === 0 || /\s$/.test(text))
+    ) {
+      // A tag ("#...") that starts a new word inside a symbol token's text
+      // (e.g. the due date "📅 2021-09-08 #mytag") must not be absorbed into
+      // that token: otherwise later edits to the symbol token (e.g. changing
+      // the date) would silently delete the tag. Close the current symbol
+      // token here and start a new plain-text ("") token that the tag (and
+      // anything after it, up to the next symbol) will belong to.
+      fillPreviousToken();
+      currentToken = null;
+      text = c;
     } else {
       text += c;
     }


### PR DESCRIPTION
## Summary

With the Tasks plugin format, a tag placed after the due date (`- [ ] Task 📅 2021-09-08 #mytag`) was silently deleted when the date was edited via the date picker, even with tag removal disabled — reported as data destruction.

`splitBySymbol()` only split on the registered emoji symbols, so `#mytag` was lumped into the 📅 token's text; editing the date replaced the token's whole text. The tokenizer now closes the current symbol token when a `#` starts a new word inside a symbol token's text, putting the tag into its own plain-text token that date edits cannot touch.

Behavior guarantees, covered by tests:

- Tags in the title (before any symbol) are handled exactly as before.
- A `#` inside a word does not split.
- Tokenization round-trips exactly (`join()` reproduces the input byte-for-byte).
- Only the Tasks plugin format uses this tokenizer; other formats are unaffected.

Fixes #141

## Test plan

- `npx jest`: 69/69 pass (8 new; no existing expectations changed)
- `npm run lint:fix` / `npm run build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)