### PR TITLE
Add excluded files/folders setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ export default class ReminderPlugin extends Plugin {
       () => {
         this.ui.reload(true);
       },
+      () => this.settings.excludedPaths.value,
     );
     this._notificationWorker = new NotificationWorker({
       registerInterval: (id) => this.registerInterval(id),

--- a/src/model/exclusion.test.ts
+++ b/src/model/exclusion.test.ts
@@ -1,0 +1,50 @@
+import { isPathExcluded } from "./exclusion";
+
+describe("isPathExcluded()", (): void => {
+  test("exact file match", (): void => {
+    expect(isPathExcluded("Templates/Daily.md", ["Templates/Daily.md"])).toBe(
+      true,
+    );
+  });
+
+  test("folder-prefix match", (): void => {
+    expect(isPathExcluded("Templates/Daily.md", ["Templates"])).toBe(true);
+  });
+
+  test("folder entry matches itself", (): void => {
+    expect(isPathExcluded("Templates", ["Templates"])).toBe(true);
+  });
+
+  test("segment-boundary non-match", (): void => {
+    expect(isPathExcluded("Templates2/Daily.md", ["Templates"])).toBe(false);
+  });
+
+  test("leading slash on entry is normalized", (): void => {
+    expect(isPathExcluded("Templates/Daily.md", ["/Templates"])).toBe(true);
+  });
+
+  test("trailing slash on entry is normalized", (): void => {
+    expect(isPathExcluded("Templates/Daily.md", ["Templates/"])).toBe(true);
+  });
+
+  test("blank entries are ignored", (): void => {
+    expect(isPathExcluded("Templates/Daily.md", ["", "   ", "\n"])).toBe(false);
+  });
+
+  test("empty list never excludes", (): void => {
+    expect(isPathExcluded("Templates/Daily.md", [])).toBe(false);
+  });
+
+  test("nested folder entries", (): void => {
+    expect(isPathExcluded("Archive/2020/Notes/foo.md", ["Archive/2020"])).toBe(
+      true,
+    );
+    expect(isPathExcluded("Archive/2021/Notes/foo.md", ["Archive/2020"])).toBe(
+      false,
+    );
+  });
+
+  test("unrelated path does not match", (): void => {
+    expect(isPathExcluded("Journal/2024-01-01.md", ["Templates"])).toBe(false);
+  });
+});

--- a/src/model/exclusion.ts
+++ b/src/model/exclusion.ts
@@ -1,0 +1,35 @@
+/**
+ * Normalizes a vault-relative path for exclusion matching: trims whitespace
+ * and strips leading/trailing slashes so entries like "/Templates/" and
+ * "Templates" are treated the same.
+ */
+function normalize(path: string): string {
+  return path.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+/**
+ * Checks whether `filePath` should be excluded from reminder scanning based
+ * on `excludedPaths`, a list of vault-relative path prefixes (analogous to
+ * Obsidian's own "Excluded files" setting).
+ *
+ * A file is excluded when its path equals an entry, or is inside the folder
+ * an entry names (matched on a path-segment boundary, so `"Templates"`
+ * excludes `"Templates/foo.md"` but not `"Templates2/foo.md"`). Blank
+ * entries never match anything. Matching is case-sensitive, since vault
+ * paths are case-sensitive.
+ */
+export function isPathExcluded(
+  filePath: string,
+  excludedPaths: Array<string>,
+): boolean {
+  const normalizedFilePath = normalize(filePath);
+  return excludedPaths.some((rawEntry) => {
+    const entry = normalize(rawEntry);
+    if (entry.length === 0) {
+      return false;
+    }
+    return (
+      normalizedFilePath === entry || normalizedFilePath.startsWith(`${entry}/`)
+    );
+  });
+}

--- a/src/plugin/filesystem.ts
+++ b/src/plugin/filesystem.ts
@@ -1,5 +1,6 @@
 import type ReminderPlugin from "main";
 import { Content } from "model/content";
+import { isPathExcluded } from "model/exclusion";
 import type { Reminder, Reminders } from "model/reminder";
 import { TAbstractFile, TFile, Vault } from "obsidian";
 
@@ -8,6 +9,7 @@ export class ReminderPluginFileSystem {
     private vault: Vault,
     private reminders: Reminders,
     private onRemindersChanged: () => void,
+    private excludedPaths: () => Array<string>,
   ) {}
 
   onload(plugin: ReminderPlugin) {
@@ -50,6 +52,12 @@ export class ReminderPluginFileSystem {
     if (!this.isMarkdownFile(file)) {
       console.debug("Not a markdown file: file=%o", file);
       return false;
+    }
+    if (isPathExcluded(file.path, this.excludedPaths())) {
+      console.debug("Excluded file: file=%o", file);
+      // The file may have had reminders from before it was excluded; make
+      // sure those are removed so the exclusion actually hides them.
+      return this.reminders.removeByFile(file.path);
     }
     const content = new Content(file.path, await this.vault.cachedRead(file));
     const reminders = content.getReminders();

--- a/src/plugin/settings/helper.ts
+++ b/src/plugin/settings/helper.ts
@@ -530,6 +530,18 @@ export class LatersSerde implements Serde<string, Array<Later>> {
   }
 }
 
+export class ExcludedPathsSerde implements Serde<string, Array<string>> {
+  unmarshal(rawValue: string): Array<string> {
+    return rawValue
+      .split("\n")
+      .map((path) => path.trim())
+      .filter((path) => path.length > 0);
+  }
+  marshal(value: Array<string>): string {
+    return value.join("\n");
+  }
+}
+
 export class ReminderFormatTypeSerde implements Serde<
   string,
   ReminderFormatType

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -14,6 +14,7 @@ import {
 import { DateTime, Later, Time } from "model/time";
 import moment from "moment";
 import {
+  ExcludedPathsSerde,
   LatersSerde,
   RawSerde,
   ReminderFormatTypeSerde,
@@ -39,6 +40,7 @@ export class Settings {
   strictDateFormat: SettingModel<boolean, boolean>;
   autoCompleteTrigger: SettingModel<string, string>;
   primaryFormat: SettingModel<string, ReminderFormatType>;
+  excludedPaths: SettingModel<string, Array<string>>;
   useCustomEmojiForTasksPlugin: SettingModel<boolean, boolean>;
   removeTagsForTasksPlugin: SettingModel<boolean, boolean>;
   linkDatesToDailyNotes: SettingModel<boolean, boolean>;
@@ -212,6 +214,18 @@ export class Settings {
       new ReminderFormatTypeSerde(),
     );
 
+    this.excludedPaths = this.settings
+      .newSettingBuilder()
+      .key("excludedPaths")
+      .name("Excluded files/folders")
+      .desc(
+        "Reminders in these files/folders are ignored. One vault-relative path per line (e.g. Templates or Archive/2020).",
+      )
+      .tag(TAG_RESCAN)
+      .textArea("")
+      .placeHolder("Templates\nArchive/2020")
+      .build(new ExcludedPathsSerde());
+
     this.useCustomEmojiForTasksPlugin = this.settings
       .newSettingBuilder()
       .key("useCustomEmojiForTasksPlugin")
@@ -316,6 +330,7 @@ export class Settings {
     this.settings
       .newGroup("Editor")
       .addSettings(this.autoCompleteTrigger, this.primaryFormat);
+    this.settings.newGroup("File Scanning").addSettings(this.excludedPaths);
     this.settings
       .newGroup("Reminder Format - Reminder Plugin")
       .addSettings(


### PR DESCRIPTION
## Summary

Adds an "Excluded files/folders" setting (analogous to Obsidian's own Excluded files): one vault-relative path per line; reminders in matching files are ignored.

- **Matching** is a pure model-layer function (`src/model/exclusion.ts`, no `obsidian` import, unit-tested): exact file match or folder-prefix match on a path-segment boundary (`Templates` excludes `Templates/foo.md` but not `Templates2/foo.md`), slash/whitespace normalization, blank lines ignored, case-sensitive.
- **Enforcement** sits in the single choke point both the per-file reload and the full vault scan funnel through. An excluded file also gets its previously scanned reminders removed, so adding an exclusion hides existing entries rather than just future ones.
- **Setting changes trigger a full rescan** via the existing `TAG_RESCAN` mechanism (same as the date-format and format-enable settings), so exclusions apply without restarting Obsidian.

Fixes #167
Fixes #194

## Test plan

- `npx jest`: 71/71 pass (10 new for the matching predicate)
- `npm run lint:fix` / `npm run build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)