### PR TITLE
docs: catch up docs with recently merged features, add docs-update reminder hook

### DIFF
--- a/.claude/hooks/docs-update-reminder.sh
+++ b/.claude/hooks/docs-update-reminder.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Stop hook
+#
+# Reminds Claude to update the documentation site (docs/src/) when a change
+# set touches user-facing source (src/**/*.ts, src/**/*.svelte, excluding
+# *.test.ts) but nothing under docs/ has been touched. Several PRs (new
+# settings, new reminder syntax) have shipped without the corresponding docs
+# update; this hook is the recurrence prevention.
+#
+# Unlike manual-verify-reminder.sh (which only looks at uncommitted changes),
+# this hook also looks at commits already made on the current branch that
+# aren't on the default branch yet, because docs omissions are usually
+# noticed after the code has already been committed on a feature branch.
+#
+# This is a one-shot reminder, not a hard gate: some changes are genuinely
+# internal (refactors, CI, types, tests) and don't need doc updates. A hash
+# of the changed-file list + HEAD commit + content of uncommitted changed
+# files is cached in .claude/hooks/.docs-update-state; once the reminder has
+# fired for a given state, the same state is let through. Any further
+# relevant change (new commit, new edit) changes the hash and re-arms the
+# reminder.
+#
+# Reads the Stop hook JSON payload from stdin, e.g.:
+#   {"cwd": "/abs/project/dir", ...}
+#
+# Exit codes:
+#   0 - nothing to remind about, docs were already touched, or already
+#       reminded for this state
+#   2 - reminder fired; instructions written to stderr
+
+set -uo pipefail
+
+input="$(cat)"
+
+json_field() {
+  local filter="$1"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$input" | jq -r "$filter // empty" 2>/dev/null
+  elif command -v node >/dev/null 2>&1; then
+    NODE_JSON_INPUT="$input" NODE_JSON_FILTER="$filter" node -e '
+      try {
+        const data = JSON.parse(process.env.NODE_JSON_INPUT || "{}");
+        const filter = process.env.NODE_JSON_FILTER;
+        let value;
+        if (filter === ".cwd") {
+          value = data.cwd;
+        }
+        process.stdout.write(value ? String(value) : "");
+      } catch (e) {
+        process.stdout.write("");
+      }
+    ' 2>/dev/null
+  fi
+}
+
+project_dir="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$project_dir" ]; then
+  project_dir="$(json_field '.cwd')"
+fi
+if [ -z "$project_dir" ]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  project_dir="$(cd "$script_dir/../.." && pwd)"
+fi
+
+cd "$project_dir" || exit 0
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# 1. Working-tree changes (tracked + untracked), any path.
+worktree_files="$(git status --porcelain 2>/dev/null | awk '{print $2}')"
+
+# 2. Commits on the current branch not yet on the default branch. If we're
+# on the default branch itself, detached, or can't find a sensible
+# merge-base, fall back to working-tree-only (branch_files stays empty).
+branch_files=""
+current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+if [ -n "$current_branch" ] && [ "$current_branch" != "HEAD" ] && [ "$current_branch" != "master" ] && [ "$current_branch" != "main" ]; then
+  base_ref=""
+  if git rev-parse --verify -q origin/master >/dev/null; then
+    base_ref="origin/master"
+  elif git rev-parse --verify -q master >/dev/null; then
+    base_ref="master"
+  fi
+  if [ -n "$base_ref" ]; then
+    merge_base="$(git merge-base HEAD "$base_ref" 2>/dev/null)"
+    if [ -n "$merge_base" ]; then
+      branch_files="$(git diff --name-only "$merge_base" HEAD 2>/dev/null)"
+    fi
+  fi
+fi
+
+all_changed_files="$(printf '%s\n%s\n' "$worktree_files" "$branch_files" | sed '/^$/d' | sort -u)"
+
+if [ -z "$all_changed_files" ]; then
+  exit 0
+fi
+
+# Filter to potentially user-facing source: src/**/*.ts or src/**/*.svelte,
+# excluding *.test.ts.
+source_files="$(printf '%s\n' "$all_changed_files" | grep -E '^src/.*\.(ts|svelte)$' | grep -v '\.test\.ts$')"
+
+if [ -z "$source_files" ]; then
+  exit 0
+fi
+
+# If docs were touched anywhere in the same change set, assume the docs
+# question has already been considered.
+docs_files="$(printf '%s\n' "$all_changed_files" | grep -E '^docs/' || true)"
+if [ -n "$docs_files" ]; then
+  exit 0
+fi
+
+state_dir=".claude/hooks"
+state_file="$state_dir/.docs-update-state"
+mkdir -p "$state_dir"
+
+hash_cmd=""
+if command -v shasum >/dev/null 2>&1; then
+  hash_cmd="shasum -a 256"
+elif command -v sha256sum >/dev/null 2>&1; then
+  hash_cmd="sha256sum"
+fi
+
+head_sha="$(git rev-parse HEAD 2>/dev/null)"
+
+current_hash=""
+if [ -n "$hash_cmd" ]; then
+  current_hash="$(
+    {
+      printf '%s\n' "$source_files"
+      printf 'HEAD:%s\n' "$head_sha"
+      while IFS= read -r f; do
+        [ -f "$f" ] && cat "$f"
+      done <<<"$worktree_files"
+    } | $hash_cmd | awk '{print $1}'
+  )"
+fi
+
+last_hash=""
+if [ -f "$state_file" ]; then
+  last_hash="$(cat "$state_file" 2>/dev/null)"
+fi
+
+if [ -n "$current_hash" ] && [ "$current_hash" = "$last_hash" ]; then
+  # Already reminded for exactly this set of changes.
+  exit 0
+fi
+
+if [ -n "$current_hash" ]; then
+  printf '%s' "$current_hash" >"$state_file"
+fi
+
+{
+  echo "Docs reminder: this change set touches src/ but nothing under docs/src/."
+  echo ""
+  echo "If this change is user-facing (new/changed settings, reminder syntax, UI"
+  echo "behavior, notification behavior), update the VuePress docs before finishing:"
+  echo "  - Settings reference: docs/src/setting/README.md"
+  echo "  - Guides: docs/src/guide/*.md"
+  echo ""
+  echo "If this change is genuinely internal (refactor, CI, types, tests), briefly"
+  echo "state that reasoning to the user and finish. This reminder fires once per"
+  echo "change state and will not block again until the sources or commits change"
+  echo "further."
+} >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,11 @@
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/manual-verify-reminder.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/docs-update-reminder.sh",
+            "timeout": 30
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ data.json
 .claude/settings.local.json
 .claude/hooks/.stop-check-state
 .claude/hooks/.manual-verify-state
+.claude/hooks/.docs-update-state
 .claude/worktrees/

--- a/docs/src/guide/interop-tasks.md
+++ b/docs/src/guide/interop-tasks.md
@@ -19,8 +19,14 @@ When you [toggle checklist status](/guide/set-reminders.html#toggle-checklist-st
 - [x] Task 📅 2021-09-16 ✅ 2021-09-17
 ```
 
+The due date can also carry a time, as an extension beyond what the Tasks Plugin itself supports. In this case, the reminder fires at that time instead of the [default reminder time](/setting/#reminder-time).
+
+```markdown
+- [ ] Task 📅 2021-09-16 10:00
+```
+
 ::: warning Note
-- You cannot change this time format for interoperability with Tasks Plugin
+- You can't customize the due date format (`YYYY-MM-DD`, optionally followed by ` HH:mm`) for interoperability with Tasks Plugin
 - If you want to specify the reminder time separately from the due date in the Tasks Plugin, you can use [reminder emoji](#distinguish-due-date-and-reminder-date).
 :::
 

--- a/docs/src/guide/list-reminders.md
+++ b/docs/src/guide/list-reminders.md
@@ -15,10 +15,14 @@ If you click the reminder, the file in which you defined the reminder will be op
 
 ## Overdue Reminders
 
-If you [mute](/guide/notification.html#mute-notification) the reminders, they will be displayed in `Overdue` section in reminder list view.
+Reminders whose time has passed are displayed in the `Overdue` section in reminder list view, whether or not you [muted](/guide/notification.html#mute-notification) them. This keeps the list meaningful even when [Enable reminder notifications](/setting/#enable-reminder-notifications) is off.
 
 <img :src="$withBase('/images/reminder-list-overdue.png')" width="300px">
 
 When you click the overdue reminder, the [reminder notification](/guide/notification.html) will be shown again.
 
 <img :src="$withBase('/images/notification-builtin.png')" width="400px">
+
+::: tip
+If [Open note on reminder click](/setting/#open-note-on-reminder-click) is enabled, clicking an overdue reminder opens the note directly instead.
+:::

--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -34,7 +34,7 @@ Instead of built-in notification, a system notification is also available by [se
 
 <img :src="$withBase('/images/notification-mac.png')" width="400px">
 
-- If you click the notification, the built-in notification will be displayed in the Obsidian app.
+- If you click the notification, the built-in notification will be displayed in the Obsidian app, unless [Open note on reminder click](/setting/#open-note-on-reminder-click) is enabled, in which case the note is opened directly instead.
 - If you close the notification, the reminder is [muted](#mute-notification)
 
 Also, if you are using macOS, you can mark it as done or postpone the reminder with the notification options.

--- a/docs/src/guide/set-reminders.md
+++ b/docs/src/guide/set-reminders.md
@@ -8,6 +8,8 @@ You can set reminders by putting `(@YYYY-MM-DD HH:mm)` to the TODO list.
 - [ ] Task 1 (@2021-09-15 20:40)
 ```
 
+Any of `-`, `*`, or `+` can be used as the list marker.
+
 Time is omittable.
 
 ```markdown
@@ -43,11 +45,15 @@ Also, you can set reminder time with time picker.
 
 :::
 
+::: tip
+The calendar popup can only insert a reminder into a checklist/task line (e.g. `- [ ] Task`). On other lines, a notice is shown instead.
+:::
+
 There are multiple ways to display the calendar popup.
 
 ### Key input trigger (Desktop only)
 
-When you input `(@` in TODO list item, you will see calendar/time picker popup.
+When you input `(@` in TODO list item, you will see calendar/time picker popup. In Live Preview, the popup appears inline, right next to the cursor. It's dismissed with <kbd>Esc</kbd> or by clicking outside of it.
 
 <img :src="$withBase('/images/reminder-input-support.png')" width="400px">
 
@@ -85,6 +91,8 @@ You can move focus to time picker by <kbd>Tab</kbd> key.
 
 Open the command palette and search `Show calendar popup`.
 It will open the calendar popup.
+
+Unlike the inline popup shown when typing the trigger, this always opens as a dialog — this is also how the calendar popup is shown on mobile.
 
 ::: tip
 For mobile users, it would be useful to add a button to the toolbar at the bottom of the markdown editor to show the calendar popup.

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -53,6 +53,26 @@ Reminder format for generated reminder by calendar popup.
   - [Tasks plugin format](/guide/interop-tasks.html)
   - [Kanban plugin format](/guide/interop-kanban.html)
 
+## Excluded files/folders
+
+Reminders in these files/folders are ignored when scanning the vault, and any reminders already found in them are removed.
+
+- Type: `string`
+- Format: Line-separated list of vault-relative paths. One path per line.
+  - An entry matches the file/folder itself and everything under it, on a path-segment boundary. For example, `Templates` excludes `Templates/Daily.md`, but not `Templates2/Daily.md`.
+  - Leading/trailing slashes are ignored.
+  - Matching is case-sensitive.
+- Default: (empty)
+
+Example
+
+```
+Templates
+Archive/2020
+```
+
+Takes effect immediately; you don't need to restart Obsidian.
+
 ## Link dates to daily notes
 
 You can link dates to daily notes with this option.
@@ -84,6 +104,26 @@ You can change option which will be shown when you click `Remind Me Later` butto
   - In N minutes/hours/days/weeks/months/years
   - Next Sunday/Monday/Tuesday/Wednesday/Thursday/Friday/Saturday/day/week/month/year
   - Tomorrow
+
+## Enable reminder notifications
+
+Show reminder popups and system notifications when a reminder is due.
+
+- Type: `boolean`
+- Values:
+  - ON: Reminder popups/system notifications are shown when due (default)
+  - OFF: Reminder popups/system notifications are suppressed. The [reminder list view](/guide/list-reminders.html) keeps updating, and expired reminders still move to the [Overdue section](/guide/list-reminders.html#overdue-reminders).
+- Default: ON
+
+## Open note on reminder click
+
+Open the note directly instead of showing the reminder popup when you click a reminder.
+
+- Type: `boolean`
+- Values:
+  - ON: Clicking a reminder in the [reminder list](/guide/list-reminders.html), or clicking a system notification, opens the note directly.
+  - OFF: Clicking an overdue/muted reminder shows the [reminder popup](/guide/notification.html) again. Clicking a system notification shows the builtin notification in Obsidian.
+- Default: OFF
 
 ## Use system notification
 


### PR DESCRIPTION
## Summary

Today's merged PRs shipped several user-facing changes without the corresponding documentation updates. This PR catches the docs up and adds a recurrence-prevention hook.

### Docs updates

- **Excluded files/folders setting (#313)**: new section in `docs/src/setting/README.md` documenting path syntax and matching semantics (segment-boundary prefix match, case-sensitive, immediate effect)
- **Notification settings (#306)**: new "Enable reminder notifications" and "Open note on reminder click" sections in the settings reference; updated `guide/notification.md` (system notification click behavior) and `guide/list-reminders.md` (Overdue grouping is now time-based, not mute-only; click behavior tip)
- **Tasks plugin due date time (#312)**: added a `📅 YYYY-MM-DD HH:mm` example to `guide/interop-tasks.md` and corrected the now-inaccurate "You cannot change this time format" note
- **Inline date/time chooser (#307)**: `guide/set-reminders.md` now describes the inline popup in Live Preview (Esc / click-outside dismissal) and clarifies that the command trigger and mobile still use the dialog
- **Small clarifications**: calendar popup only works on task lines (#303 / #190 / #176); `-`, `*`, `+` are all valid list markers (#260)

### Recurrence prevention

- New Stop hook `.claude/hooks/docs-update-reminder.sh` (registered in `.claude/settings.json`): fires once per change state when the change set (working tree + branch commits not on master) touches `src/**/*.ts` / `src/**/*.svelte` (excluding `*.test.ts`) but nothing under `docs/`. Modeled after `manual-verify-reminder.sh`.

### Remaining follow-up

- The screenshot `reminder-input-support.png` in `guide/set-reminders.md` still shows the pre-#307 modal-style popup; a fresh screenshot of the inline popup should be taken manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)