### PR TITLE
Document the convert non-task lines setting (#314)

### DIFF
--- a/docs/src/guide/set-reminders.md
+++ b/docs/src/guide/set-reminders.md
@@ -102,6 +102,14 @@ For mobile users, it would be useful to add a button to the toolbar at the botto
 3. Select the command named `Show calendar popup`
    :::
 
+### Using the trigger on a non-task line
+
+If you pick a date while the cursor is on a line that isn't a task list item, that line is automatically converted into an unchecked task (`- [ ] `) before the reminder is inserted. Bullets get a checkbox; plain text and empty lines get `- [ ] ` prepended.
+
+Headings, numbered lists, table rows, and code fences are not converted — a notice is shown instead, and nothing is inserted.
+
+This behavior is controlled by [Convert non-task lines when inserting a reminder](/setting/#convert-non-task-lines-when-inserting-a-reminder). If you disable it, a notice is always shown for non-task lines instead of converting them.
+
 ## Toggle checklist status
 
 This plugin provides 2 ways to toggle checklist status.

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -43,6 +43,16 @@ Trigger to show calendar popup.
 - Format: Any string. If you make this setting empty string, calendar popup will be disabled.
 - Default: `(@`
 
+## Convert non-task lines when inserting a reminder
+
+When inserting a reminder from the [calendar popup](/guide/set-reminders.html#reminder-date-input-support) on a line that is not a task, the line is automatically converted into a task list item (`- [ ] `). Bullets (`- `, `* `, `+ `) get a checkbox inserted after the marker, and plain text or empty lines get `- [ ] ` prepended. Headings, numbered lists, tables, and code fences are not converted; a notice is shown instead.
+
+- Type: `boolean`
+- Values:
+  - ON: Non-task lines are converted into tasks automatically (default)
+  - OFF: A notice is always shown for non-task lines
+- Default: ON
+
 ## Primary reminder format
 
 Reminder format for generated reminder by calendar popup.


### PR DESCRIPTION
## Summary

Documentation for #314 (convert non-task lines when inserting a reminder) — the only recently shipped feature not yet covered by the docs after #315's catch-up:

- **Settings page**: new "Convert non-task lines when inserting a reminder" entry, inserted between "Calendar popup trigger" and "Primary reminder format" to match the settings UI order.
- **Set-reminders guide**: "Using the trigger on a non-task line" subsection — auto-conversion behavior, the conservatively non-converted line types (headings, numbered lists, table rows, code fences), and the setting link.

This PR originally also documented #306/#312/#313, but #315 landed equivalent docs first, so it has been rebuilt on top of master with only the missing #314 coverage (conflict resolved by adopting master's wording everywhere else).

## Test plan

- `npm run build` in docs/ (VuePress) succeeds
- Internal anchors verified against actual headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)