### PR TITLE
Optionally show the reminder popup together with system notification

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -39,6 +39,10 @@ Instead of built-in notification, a system notification is also available by [se
 
 Also, if you are using macOS, you can mark it as done or postpone the reminder with the notification options.
 
+### Showing the popup together with the system notification
+
+If you'd rather not lose the popup's actions, enable [Show popup together with system notification](/setting/#show-popup-together-with-system-notification) alongside `Use system notification`. The built-in reminder popup is then shown at the same time as the system notification, and the popup becomes the surface that handles the reminder actions (mark as done/remind me later/mute/open note). The system notification acts as an alert only: clicking it just closes it, or opens the note directly when [Open note on reminder click](/setting/#open-note-on-reminder-click) is enabled.
+
 ## Mute notification
 
 The reminder will be muted if you do the following:

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -146,6 +146,18 @@ Only available on desktop OS.
   - ON: Use system notification. In mobile devices, this setting is ignored and builtin notification is used.
   - OFF: Use builtin notification
 
+## Show popup together with system notification
+
+Show the built-in reminder popup at the same time as the system notification.
+
+Only takes effect while [Use system notification](#use-system-notification) is enabled.
+
+- Type: `boolean`
+- Values:
+  - ON: Both surfaces are shown at once. The popup handles the reminder actions (mark as done/remind me later/mute/open note); the system notification acts as an alert only, so clicking it just closes it, or opens the note when [Open note on reminder click](#open-note-on-reminder-click) is enabled.
+  - OFF: Only the system notification is shown, and it handles the reminder actions itself.
+- Default: OFF
+
 ## Enable Tasks plugin format
 
 Enable support for [Tasks Plugin](https://github.com/schemar/obsidian-tasks)

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -33,6 +33,7 @@ export class Settings {
   enableNotification: SettingModel<boolean, boolean>;
   openNoteOnReminderClick: SettingModel<boolean, boolean>;
   useSystemNotification: SettingModel<boolean, boolean>;
+  showPopupWithSystemNotification: SettingModel<boolean, boolean>;
   laters: SettingModel<string, Array<Later>>;
   weekStart: SettingModel<string, string>;
   dateFormat: SettingModel<string, string>;
@@ -98,6 +99,16 @@ export class Settings {
       .key("useSystemNotification")
       .name("Use system notification")
       .desc("Use system notification for reminder notifications")
+      .toggle(false)
+      .build(new RawSerde());
+
+    this.showPopupWithSystemNotification = this.settings
+      .newSettingBuilder()
+      .key("showPopupWithSystemNotification")
+      .name("Show popup together with system notification")
+      .desc(
+        "When using system notification, also show the built-in reminder popup at the same time. The popup handles the reminder actions; the system notification acts as an alert only.",
+      )
       .toggle(false)
       .build(new RawSerde());
 
@@ -337,6 +348,7 @@ export class Settings {
         this.enableNotification,
         this.openNoteOnReminderClick,
         this.useSystemNotification,
+        this.showPopupWithSystemNotification,
       );
     this.settings
       .newGroup("Editor")

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -52,6 +52,7 @@ export class ReminderPluginUI {
       plugin.settings.useSystemNotification,
       plugin.settings.laters,
       plugin.settings.openNoteOnReminderClick,
+      plugin.settings.showPopupWithSystemNotification,
     );
   }
 

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -11,6 +11,7 @@ export class ReminderModal {
     private useSystemNotification: ReadOnlyReference<boolean>,
     private laters: ReadOnlyReference<Array<Later>>,
     private openNoteOnReminderClick: ReadOnlyReference<boolean>,
+    private showPopupWithSystemNotification: ReadOnlyReference<boolean>,
   ) {}
 
   public show(
@@ -28,19 +29,53 @@ export class ReminderModal {
         onMute,
         onOpenFile,
       );
-    } else {
-      // Show system notification
-      const Notification = (electron as any).remote.Notification;
-      const n = new Notification({
-        title: "Obsidian Reminder",
-        body: reminder.title,
-      });
-      n.on("click", () => {
-        n.close();
-        if (this.openNoteOnReminderClick.value) {
-          onOpenFile();
-          return;
-        }
+      return;
+    }
+
+    const showBothSurfaces = this.showPopupWithSystemNotification.value;
+    if (showBothSurfaces) {
+      // The popup is the single owner of the reminder's lifecycle in this
+      // mode, so the system notification must not also wire up mute/done
+      // actions -- otherwise both surfaces would fire onDone/onMute for the
+      // same reminder. It is shown as an alert only.
+      this.showBuiltinReminder(
+        reminder,
+        onRemindMeLater,
+        onDone,
+        onMute,
+        onOpenFile,
+      );
+    }
+    this.showSystemNotification(
+      reminder,
+      onRemindMeLater,
+      onDone,
+      onMute,
+      onOpenFile,
+      showBothSurfaces,
+    );
+  }
+
+  private showSystemNotification(
+    reminder: Reminder,
+    onRemindMeLater: (time: DateTime) => void,
+    onDone: () => void,
+    onMute: () => void,
+    onOpenFile: () => void,
+    alertOnly: boolean,
+  ) {
+    const Notification = (electron as any).remote.Notification;
+    const n = new Notification({
+      title: "Obsidian Reminder",
+      body: reminder.title,
+    });
+    n.on("click", () => {
+      n.close();
+      if (this.openNoteOnReminderClick.value) {
+        onOpenFile();
+        return;
+      }
+      if (!alertOnly) {
         this.showBuiltinReminder(
           reminder,
           onRemindMeLater,
@@ -48,7 +83,9 @@ export class ReminderModal {
           onMute,
           onOpenFile,
         );
-      });
+      }
+    });
+    if (!alertOnly) {
       n.on("close", () => {
         onMute();
       });
@@ -69,9 +106,9 @@ export class ReminderModal {
         });
         n.actions = actions as any;
       }
-
-      n.show();
     }
+
+    n.show();
   }
 
   private showBuiltinReminder(


### PR DESCRIPTION
## Summary

Adds "Show popup together with system notification" (default off). When enabled with system notifications, the built-in reminder popup is shown at the same time: the popup is the single owner of the reminder's lifecycle (done / remind-me-later / mute / open), and the system notification is wired as an alert only — no mute-on-close, no macOS action buttons — so the two surfaces cannot double-fire callbacks. Clicking the notification closes it (and opens the note when "Open note on reminder click" is enabled).

With the setting off, behavior is unchanged from today.

Fixes #265

## Test plan

- `npx jest`: 94/94 pass (UI layer — no unit-testable surface)
- `npm run lint:fix` / `npm run build`: clean
- Manual verification in a test vault to follow on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)