### PR TITLE
Add a do-not-disturb mode for reminder notifications

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -51,3 +51,18 @@ The reminder will be muted if you do the following:
 A muted reminder will not be notified again until
 - you restart the Obsidian app
 - you click muted reminder in [reminder list view](/guide/list-reminders.html)
+
+## Pausing notifications temporarily (do not disturb)
+
+Unlike the [Enable reminder notifications](/setting/#enable-reminder-notifications) setting, which turns notifications off permanently until you turn it back on, do-not-disturb lets you pause notifications for a fixed duration and have them resume automatically.
+
+You can start it from either place:
+- Run `Pause reminder notifications` from the command palette. It opens a duration chooser with the same options as the [Remind Me Later](/setting/#remind-me-later) setting.
+- Click `Pause all notifications…` at the bottom of a notification popup. This closes the popup (without [muting](#mute-notification) that reminder) and opens the same duration chooser.
+
+While paused:
+- No builtin notification popups or system notifications are shown.
+- The [reminder list view](/guide/list-reminders.html) keeps updating as usual, including moving reminders into [Overdue](/guide/list-reminders.html#overdue-reminders).
+- Reminders are not muted by the pause, so any reminder that's still overdue is notified again shortly after the pause ends.
+
+A status bar item (🔕) shows the time the pause ends; click it to resume notifications immediately. You can also run `Resume reminder notifications` from the command palette, which is only available while paused. The pause is remembered across Obsidian restarts, but it's a transient state rather than a setting, so it doesn't appear in the settings tab.

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,9 @@ import {
   ReminderPluginFileSystem,
   ReminderPluginUI,
 } from "plugin";
+import { isNotificationPaused } from "model/dnd";
 import { Reminders } from "model/reminder";
-import { DATE_TIME_FORMATTER } from "model/time";
+import { DATE_TIME_FORMATTER, DateTime } from "model/time";
 import type { Settings } from "plugin/settings";
 import { App, Plugin } from "obsidian";
 import type { PluginManifest } from "obsidian";
@@ -72,6 +73,8 @@ export default class ReminderPlugin extends Plugin {
         this.reminders.getExpiredReminders(this.settings.reminderTime.value),
       checkIntervalSec: () => this.settings.reminderCheckIntervalSec.value,
       isNotificationEnabled: () => this.settings.enableNotification.value,
+      isNotificationPaused: () =>
+        isNotificationPaused(this.data.dndUntil.value, DateTime.now()),
     });
   }
 

--- a/src/model/dnd.test.ts
+++ b/src/model/dnd.test.ts
@@ -1,0 +1,30 @@
+import { isNotificationPaused } from "./dnd";
+import { DateTime } from "./time";
+
+describe("isNotificationPaused()", (): void => {
+  test("returns false when dndUntil is not set", (): void => {
+    expect(isNotificationPaused(null, DateTime.parse("2021-09-08 10:00"))).toBe(
+      false,
+    );
+  });
+
+  test("returns true when now is before dndUntil", (): void => {
+    const dndUntil = DateTime.parse("2021-09-08 11:00");
+    const now = DateTime.parse("2021-09-08 10:00");
+
+    expect(isNotificationPaused(dndUntil, now)).toBe(true);
+  });
+
+  test("returns false once now reaches dndUntil", (): void => {
+    const dndUntil = DateTime.parse("2021-09-08 11:00");
+
+    expect(isNotificationPaused(dndUntil, dndUntil)).toBe(false);
+  });
+
+  test("returns false once now is after dndUntil", (): void => {
+    const dndUntil = DateTime.parse("2021-09-08 11:00");
+    const now = DateTime.parse("2021-09-08 12:00");
+
+    expect(isNotificationPaused(dndUntil, now)).toBe(false);
+  });
+});

--- a/src/model/dnd.ts
+++ b/src/model/dnd.ts
@@ -1,0 +1,20 @@
+import type { DateTime } from "model/time";
+
+/**
+ * Whether reminder notifications should currently be suppressed by
+ * do-not-disturb mode.
+ *
+ * `dndUntil` is the time do-not-disturb was set to expire at (or `null` if
+ * do-not-disturb is not active). Notifications stay paused only while `now`
+ * is strictly before `dndUntil`; reminders are never muted by this check, so
+ * anything still expired fires again once the pause ends.
+ */
+export function isNotificationPaused(
+  dndUntil: DateTime | null,
+  now: DateTime,
+): boolean {
+  if (dndUntil == null) {
+    return false;
+  }
+  return now.getTimeInMillis() < dndUntil.getTimeInMillis();
+}

--- a/src/model/time.ts
+++ b/src/model/time.ts
@@ -15,6 +15,16 @@ export class DateTime {
     }
   }
 
+  /**
+   * Builds a `DateTime` from an epoch-milliseconds timestamp. Used for
+   * persisting values (e.g. do-not-disturb's `dndUntil`) that must survive a
+   * round trip through storage without losing precision, unlike
+   * `toString()`/`parse()` which are lossy for date-only `DateTime`s.
+   */
+  public static ofEpochMillis(epochMillis: number): DateTime {
+    return new DateTime(moment(epochMillis), true);
+  }
+
   public static duration(
     from: DateTime,
     to: DateTime,

--- a/src/plugin/commands/index.ts
+++ b/src/plugin/commands/index.ts
@@ -1,5 +1,7 @@
 import type ReminderPlugin from "main";
 import { MarkdownView } from "obsidian";
+import { pauseNotifications } from "./pause-notifications";
+import { resumeNotifications } from "./resume-notifications";
 import { scanReminders } from "./scan-reminders";
 import { showReminderList } from "./show-reminder-list";
 import { convertReminderTimeFormat } from "./convert-reminder-time-format";
@@ -70,6 +72,22 @@ export function registerCommands(plugin: ReminderPlugin) {
     name: "Set date display format",
     checkCallback: (checking: boolean) => {
       return setDateDisplayFormat(checking, plugin);
+    },
+  });
+
+  plugin.addCommand({
+    id: "pause-notifications",
+    name: "Pause reminder notifications",
+    checkCallback: (checking: boolean) => {
+      return pauseNotifications(checking, plugin);
+    },
+  });
+
+  plugin.addCommand({
+    id: "resume-notifications",
+    name: "Resume reminder notifications",
+    checkCallback: (checking: boolean) => {
+      return resumeNotifications(checking, plugin);
     },
   });
 }

--- a/src/plugin/commands/pause-notifications.ts
+++ b/src/plugin/commands/pause-notifications.ts
@@ -1,0 +1,13 @@
+import type ReminderPlugin from "main";
+import { showPauseDurationChooser } from "plugin/dnd";
+
+export function pauseNotifications(
+  checking: boolean,
+  plugin: ReminderPlugin,
+): boolean {
+  if (checking) {
+    return true;
+  }
+  showPauseDurationChooser(plugin);
+  return true;
+}

--- a/src/plugin/commands/resume-notifications.ts
+++ b/src/plugin/commands/resume-notifications.ts
@@ -1,0 +1,24 @@
+import type ReminderPlugin from "main";
+import { isNotificationPaused } from "model/dnd";
+import { DateTime } from "model/time";
+import { resumeNotifications as clearDnd } from "plugin/dnd";
+
+export function resumeNotifications(
+  checking: boolean,
+  plugin: ReminderPlugin,
+): boolean {
+  const paused = isNotificationPaused(
+    plugin.data.dndUntil.value,
+    DateTime.now(),
+  );
+  if (!paused) {
+    // Only enabled while paused, mirroring how other commands gate on
+    // whether their action currently makes sense.
+    return false;
+  }
+  if (checking) {
+    return true;
+  }
+  clearDnd(plugin);
+  return true;
+}

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -26,6 +26,12 @@ export class PluginData {
   changed: boolean = false;
   public scanned: Reference<boolean> = new Reference(false);
   public debug: Reference<boolean> = new Reference(false);
+  // Do-not-disturb end time, or `null` while do-not-disturb is inactive.
+  // Transient state (not a setting): not exposed in the settings tab, but
+  // still persisted so a pause survives an Obsidian restart.
+  public dndUntil: Reference<DateTime | null> = new Reference<DateTime | null>(
+    null,
+  );
   private readonly _settings = new Settings();
 
   constructor(
@@ -57,6 +63,7 @@ export class PluginData {
       | {
           scanned: boolean;
           debug?: boolean;
+          dndUntil?: number | null;
           settings?: Record<string, unknown>;
           reminders?: Record<string, Array<ReminderData>>;
         }
@@ -69,6 +76,8 @@ export class PluginData {
     if (data.debug != null) {
       this.debug.value = data.debug;
     }
+    this.dndUntil.value =
+      data.dndUntil != null ? DateTime.ofEpochMillis(data.dndUntil) : null;
 
     this.settings.forEach((setting) => {
       setting.load(data.settings);
@@ -127,6 +136,7 @@ export class PluginData {
       scanned: this.scanned.value,
       reminders: remindersData,
       debug: this.debug.value,
+      dndUntil: this.dndUntil.value?.getTimeInMillis() ?? null,
       settings,
     });
     this.changed = false;

--- a/src/plugin/dnd.ts
+++ b/src/plugin/dnd.ts
@@ -1,0 +1,35 @@
+import type ReminderPlugin from "main";
+import type { Later } from "model/time";
+import { Notice } from "obsidian";
+import { DndDurationModal } from "plugin/ui/dnd-duration-chooser";
+
+/**
+ * Do-not-disturb actions shared by the "Pause reminder notifications" /
+ * "Resume reminder notifications" commands, the status bar indicator, and
+ * the "Pause all notifications..." link in the reminder popup, so all of
+ * them stay in sync on how `dndUntil` is set/cleared, persisted, and
+ * reported to the user.
+ */
+
+export function pauseNotifications(plugin: ReminderPlugin, later: Later): void {
+  const until = later.later();
+  plugin.data.dndUntil.value = until;
+  void plugin.data.save(true);
+  plugin.ui.refreshDndStatusBar();
+  new Notice(
+    `Reminder notifications paused until ${until.format("YYYY-MM-DD HH:mm")}`,
+  );
+}
+
+export function resumeNotifications(plugin: ReminderPlugin): void {
+  plugin.data.dndUntil.value = null;
+  void plugin.data.save(true);
+  plugin.ui.refreshDndStatusBar();
+  new Notice("Reminder notifications resumed");
+}
+
+export function showPauseDurationChooser(plugin: ReminderPlugin): void {
+  new DndDurationModal(plugin.app, plugin.settings.laters.value, (later) => {
+    pauseNotifications(plugin, later);
+  }).open();
+}

--- a/src/plugin/notification-worker.test.ts
+++ b/src/plugin/notification-worker.test.ts
@@ -23,6 +23,7 @@ function createDeps(
     getExpiredReminders: () => [],
     checkIntervalSec: () => 60,
     isNotificationEnabled: () => true,
+    isNotificationPaused: () => false,
     ...overrides,
   };
 }
@@ -169,6 +170,57 @@ describe("NotificationWorker", (): void => {
     await callPeriodicTask(worker);
 
     expect(reloadUI).toHaveBeenCalledWith(true);
+    expect(showReminder).toHaveBeenCalledWith(reminder);
+  });
+
+  test("does not show reminders while paused (do-not-disturb)", async (): Promise<void> => {
+    const showReminder = jest.fn();
+    const deps = createDeps({
+      isNotificationPaused: () => true,
+      getExpiredReminders: () => [makeReminder("r1")],
+      showReminder,
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(showReminder).not.toHaveBeenCalled();
+  });
+
+  test("still reloads UI and scans while paused (do-not-disturb)", async (): Promise<void> => {
+    const reloadUI = jest.fn();
+    const reloadRemindersInAllFiles = jest.fn(async () => {});
+    const deps = createDeps({
+      isNotificationPaused: () => true,
+      isScanned: () => false,
+      reloadUI,
+      reloadRemindersInAllFiles,
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(reloadUI).toHaveBeenCalled();
+    expect(reloadRemindersInAllFiles).toHaveBeenCalled();
+  });
+
+  test("shows a still-expired reminder on the tick after the pause ends", async (): Promise<void> => {
+    const showReminder = jest.fn();
+    const reminder = makeReminder("r1");
+    let paused = true;
+    const deps = createDeps({
+      isNotificationPaused: () => paused,
+      getExpiredReminders: () => [reminder],
+      showReminder,
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+    expect(showReminder).not.toHaveBeenCalled();
+
+    paused = false;
+    await callPeriodicTask(worker);
+
     expect(showReminder).toHaveBeenCalledWith(reminder);
   });
 

--- a/src/plugin/notification-worker.ts
+++ b/src/plugin/notification-worker.ts
@@ -19,6 +19,7 @@ export interface NotificationWorkerDeps {
   getExpiredReminders(): Array<Reminder>;
   checkIntervalSec(): number;
   isNotificationEnabled(): boolean;
+  isNotificationPaused(): boolean;
 }
 
 export class NotificationWorker {
@@ -92,6 +93,14 @@ export class NotificationWorker {
       // initial scan, saveData, and the newly-expired forced reload) must
       // still run so the reminder list view stays up to date even while
       // popups/system notifications are suppressed.
+      return;
+    }
+
+    if (this.deps.isNotificationPaused()) {
+      // Do-not-disturb is active. As with the disabled-notifications guard
+      // above, everything above it must still run. Reminders are not muted
+      // by the pause, so anything still expired fires on the next tick once
+      // the pause ends.
       return;
     }
 

--- a/src/plugin/ui/dnd-duration-chooser.ts
+++ b/src/plugin/ui/dnd-duration-chooser.ts
@@ -1,0 +1,32 @@
+import type { Later } from "model/time";
+import { App, SuggestModal } from "obsidian";
+
+/**
+ * Lets the user pick how long to pause reminder notifications for, from the
+ * same "Remind me later" choices (`Settings.laters`) used by the reminder
+ * popup's snooze dropdown.
+ */
+export class DndDurationModal extends SuggestModal<Later> {
+  constructor(
+    app: App,
+    private laters: Array<Later>,
+    private onSelect: (later: Later) => void,
+  ) {
+    super(app);
+    this.setPlaceholder("Pause reminder notifications for...");
+  }
+
+  getSuggestions(query: string): Array<Later> {
+    return this.laters.filter((later) =>
+      later.label.toLowerCase().includes(query.toLowerCase()),
+    );
+  }
+
+  renderSuggestion(later: Later, el: HTMLElement) {
+    el.createEl("div", { text: later.label });
+  }
+
+  onChooseSuggestion(later: Later) {
+    this.onSelect(later);
+  }
+}

--- a/src/plugin/ui/dnd-status-bar.ts
+++ b/src/plugin/ui/dnd-status-bar.ts
@@ -1,0 +1,63 @@
+import type ReminderPlugin from "main";
+import { isNotificationPaused } from "model/dnd";
+import { DateTime } from "model/time";
+import { resumeNotifications } from "plugin/dnd";
+
+const REFRESH_INTERVAL_MILLIS = 10 * 1000;
+
+/**
+ * Status bar item that shows a do-not-disturb indicator (e.g. "🔕 Until
+ * 15:30") while reminder notifications are paused, and is hidden otherwise.
+ * Clicking it resumes notifications immediately.
+ */
+export class DndStatusBar {
+  // Created lazily in `onload()` rather than the constructor, since
+  // `addStatusBarItem()` is an Obsidian API call and this class (like
+  // `ReminderModal`) is constructed before the plugin has loaded.
+  private el?: HTMLElement;
+
+  constructor(private plugin: ReminderPlugin) {}
+
+  onload() {
+    this.el = this.plugin.addStatusBarItem();
+    this.el.addClass("reminder-dnd-status-bar");
+    this.el.style.display = "none";
+    this.el.style.cursor = "pointer";
+    this.el.setAttribute(
+      "aria-label",
+      "Click to resume reminder notifications",
+    );
+    this.plugin.registerDomEvent(this.el, "click", () => {
+      resumeNotifications(this.plugin);
+    });
+
+    this.plugin.registerInterval(
+      window.setInterval(() => this.refresh(), REFRESH_INTERVAL_MILLIS),
+    );
+    this.refresh();
+  }
+
+  refresh() {
+    if (!this.el) {
+      return;
+    }
+    const dndUntil = this.plugin.data.dndUntil.value;
+    if (!isNotificationPaused(dndUntil, DateTime.now())) {
+      this.el.style.display = "none";
+      return;
+    }
+    // `isNotificationPaused` returning true guarantees `dndUntil` is set.
+    this.el.setText(`🔕 Until ${this.formatUntil(dndUntil!)}`);
+    this.el.style.display = "";
+  }
+
+  private formatUntil(dndUntil: DateTime): string {
+    const timeFormat = this.plugin.settings.timeDisplayFormat.value;
+    const time = dndUntil.format(timeFormat);
+    if (dndUntil.toYYYYMMDD() === DateTime.now().toYYYYMMDD()) {
+      return time;
+    }
+    const dateFormat = this.plugin.settings.monthDayDisplayFormat.value;
+    return `${dndUntil.format(dateFormat)} ${time}`;
+  }
+}

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -11,8 +11,10 @@ import {
   WorkspaceLeaf,
 } from "obsidian";
 import { registerCommands } from "plugin/commands";
+import { showPauseDurationChooser } from "plugin/dnd";
 import { monkeyPatchConsole } from "plugin/obsidian-hack/obsidian-debug-mobile";
 import { VIEW_TYPE_REMINDER_LIST } from "./constants";
+import { DndStatusBar } from "./dnd-status-bar";
 import { ReminderListItemViewProxy } from "./reminder-list";
 import { AutoComplete } from "./autocomplete";
 import type { AutoCompletableEditor } from "./autocomplete";
@@ -24,6 +26,7 @@ export class ReminderPluginUI {
   private editDetector: EditDetector;
   private reminderModal: ReminderModal;
   private viewProxy: ReminderListItemViewProxy;
+  private dndStatusBar: DndStatusBar;
   constructor(private plugin: ReminderPlugin) {
     this.viewProxy = new ReminderListItemViewProxy(
       this.plugin,
@@ -53,9 +56,12 @@ export class ReminderPluginUI {
       plugin.settings.laters,
       plugin.settings.openNoteOnReminderClick,
     );
+    this.dndStatusBar = new DndStatusBar(plugin);
   }
 
   onload() {
+    this.dndStatusBar.onload();
+
     // Reminder List
     this.plugin.registerView(VIEW_TYPE_REMINDER_LIST, (leaf: WorkspaceLeaf) => {
       return this.viewProxy.createView(leaf);
@@ -110,12 +116,17 @@ export class ReminderPluginUI {
     this.autoComplete.show(this.plugin.app, editor, this.plugin.reminders);
   }
 
+  refreshDndStatusBar() {
+    this.dndStatusBar.refresh();
+  }
+
   private showReminderModal(
     reminder: Reminder,
     onRemindMeLater: (time: DateTime) => void,
     onDone: () => void,
     onMute: () => void,
     onOpenFile: () => void,
+    onPauseAllNotifications: () => void,
   ) {
     this.reminderModal.show(
       reminder,
@@ -123,6 +134,7 @@ export class ReminderPluginUI {
       onDone,
       onMute,
       onOpenFile,
+      onPauseAllNotifications,
     );
   }
 
@@ -207,6 +219,14 @@ export class ReminderPluginUI {
         console.debug("Open");
         // Callback is synchronous; opening the file is fire-and-forget here.
         void this.openReminderFile(reminder);
+      },
+      () => {
+        console.debug("Pause all notifications");
+        // Unlike Mute, this must not leave this specific reminder muted:
+        // pausing suppresses notifications globally without touching
+        // individual reminders, so it re-fires once the pause ends.
+        reminder.muteNotification = false;
+        showPauseDurationChooser(this.plugin);
       },
     );
   }

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -19,6 +19,7 @@ export class ReminderModal {
     onDone: () => void,
     onMute: () => void,
     onOpenFile: () => void,
+    onPauseAllNotifications: () => void,
   ) {
     if (!this.isSystemNotification()) {
       this.showBuiltinReminder(
@@ -27,6 +28,7 @@ export class ReminderModal {
         onDone,
         onMute,
         onOpenFile,
+        onPauseAllNotifications,
       );
     } else {
       // Show system notification
@@ -47,6 +49,7 @@ export class ReminderModal {
           onDone,
           onMute,
           onOpenFile,
+          onPauseAllNotifications,
         );
       });
       n.on("close", () => {
@@ -80,6 +83,7 @@ export class ReminderModal {
     onDone: () => void,
     onCancel: () => void,
     onOpenFile: () => void,
+    onPauseAllNotifications: () => void,
   ) {
     new NotificationModal(
       this.app,
@@ -89,6 +93,7 @@ export class ReminderModal {
       onDone,
       onCancel,
       onOpenFile,
+      onPauseAllNotifications,
     ).open();
   }
 
@@ -106,6 +111,11 @@ export class ReminderModal {
 
 class NotificationModal extends Modal {
   canceled: boolean = true;
+  // Set when the modal is closed via "Pause all notifications...". This
+  // takes precedence over `canceled` in `onClose()` so `onCancel` (which
+  // mutes the reminder) is skipped, letting the reminder re-fire once the
+  // pause ends.
+  private pausingAll: boolean = false;
 
   constructor(
     app: App,
@@ -115,6 +125,7 @@ class NotificationModal extends Modal {
     private onDone: () => void,
     private onCancel: () => void,
     private onOpenFile: () => void,
+    private onPauseAllNotifications: () => void,
   ) {
     super(app);
   }
@@ -149,6 +160,11 @@ class NotificationModal extends Modal {
           this.canceled = true;
           this.close();
         },
+        onPauseAllNotifications: () => {
+          this.pausingAll = true;
+          this.onPauseAllNotifications();
+          this.close();
+        },
       },
     });
   }
@@ -159,7 +175,10 @@ class NotificationModal extends Modal {
     this.reminder.beingDisplayed = false;
     const { contentEl } = this;
     contentEl.empty();
-    if (this.canceled) {
+    if (this.pausingAll) {
+      // Skip `onCancel` (mute): pausing suppresses notifications globally
+      // without muting this specific reminder.
+    } else if (this.canceled) {
       this.onCancel();
     }
   }

--- a/src/ui/Reminder.svelte
+++ b/src/ui/Reminder.svelte
@@ -10,6 +10,7 @@
   export let onDone: () => void;
   export let onOpenFile: () => void;
   export let onMute: () => void;
+  export let onPauseAllNotifications: () => void;
   // Do not set initial value so that svelte can render the placeholder `Remind Me Later`.
   let selectedIndex: number;
   export let laters: Array<Later> = [];
@@ -60,6 +61,9 @@
       {/each}
     </select>
   </div>
+  <button class="reminder-pause-all" on:click={onPauseAllNotifications}>
+    Pause all notifications…
+  </button>
 </main>
 
 <style>
@@ -89,5 +93,22 @@
 
   .later-select {
     font-size: 14px;
+  }
+
+  .reminder-pause-all {
+    display: block;
+    margin-top: 0.75rem;
+    padding: 0;
+    color: var(--text-faint);
+    cursor: pointer;
+    background-color: transparent;
+    border: none;
+    text-decoration: underline;
+    box-shadow: none;
+    font-size: 12px;
+  }
+
+  .reminder-pause-all:hover {
+    color: var(--text-muted);
   }
 </style>


### PR DESCRIPTION
## Summary

A temporary "pause all notifications" mode (issue #235), designed so the pause is state, not configuration:

- **State**: `dndUntil` is persisted in plugin data as epoch millis (survives restarts; date-only "Tomorrow"-style choices round-trip exactly). Nothing is added to the settings tab.
- **Guard**: `NotificationWorker` skips showing reminders while paused, next to the existing enable guard. The reminder list keeps updating (Overdue transitions included), and reminders are NOT muted by the pause — anything still expired fires on the next tick once the pause ends. Covered by unit tests (pause active / pause expiry over two ticks).
- **Entry points**:
  - Command "Pause reminder notifications" — duration chooser reusing the user's existing *Remind me later* options (no new duration config).
  - Command "Resume reminder notifications" — enabled only while paused.
  - "Pause all notifications…" link in the reminder popup — closes the popup **without muting that reminder**, so it re-fires after the pause.
  - Status bar indicator (`🔕 Until 15:30`, date included when not today) — click to resume. Hidden while inactive.
- A `Notice` confirms pause/resume with the end time.

Fixes #235

## Test plan

- `npx jest`: 101/101 pass (7 new: pure pause predicate + worker guard/expiry)
- `npm run lint:fix` / `npm run build`: clean
- Manual verification in a test vault to follow on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)