### PR TITLE
Fix semantically broken merge of #318 (tsc failure on master, runtime error in 1.2.0)

### DIFF
--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -46,6 +46,7 @@ export class ReminderModal {
         onDone,
         onMute,
         onOpenFile,
+        onPauseAllNotifications,
       );
     }
     this.showSystemNotification(
@@ -54,6 +55,7 @@ export class ReminderModal {
       onDone,
       onMute,
       onOpenFile,
+      onPauseAllNotifications,
       showBothSurfaces,
     );
   }
@@ -64,6 +66,7 @@ export class ReminderModal {
     onDone: () => void,
     onMute: () => void,
     onOpenFile: () => void,
+    onPauseAllNotifications: () => void,
     alertOnly: boolean,
   ) {
     const Notification = (electron as any).remote.Notification;


### PR DESCRIPTION
## Summary

**master currently fails `tsc --noEmit`, and the released 1.2.0 contains the broken code.**

The GitHub merge of #318 with #317 had no textual conflicts, so it merged automatically — but it was semantically broken: #317 restructured `ReminderModal` (extracting `showSystemNotification`) while #318 added a required `onPauseAllNotifications` callback through the same call chain. The auto-merge left:

- `show()`'s combined-mode `showBuiltinReminder(...)` call missing the now-required `onPauseAllNotifications` argument (TS2554), and
- `showSystemNotification`'s click handler referencing `onPauseAllNotifications` without it being a parameter (TS2304) — a `ReferenceError` at runtime when a system notification is clicked.

Neither jest (which only compiles the model layer) nor esbuild (which strips types without checking) catches this, which is how it passed the release pipeline into **1.2.0**.

The fix threads `onPauseAllNotifications` into `showSystemNotification` and both `showBuiltinReminder` call sites — identical to the reviewed rebase fix that was prepared on the PR branch but couldn't be pushed before the merge.

**Recommendation**: after merging, release **1.2.1**, since 1.2.0 ships the broken system-notification click path. A follow-up to prevent recurrence (run `tsc --noEmit` in the release/PR workflow) is worth considering.

## Test plan

- `npx tsc --noEmit`: clean (fails on master)
- `npx jest`: all pass
- `npm run build`: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)