### PR TITLE
ci: categorize auto-generated release notes by PR label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,9 +3,21 @@ changelog:
     - title: Breaking Changes 🛠
       labels:
         - breaking-change
-    - title: Exciting New Features 🎉
+    - title: New Features 🎉
       labels:
         - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Documentation 📚
+      labels:
+        - documentation
+    - title: Dependency Updates ⛓️
+      labels:
+        - dependencies
+    - title: Maintenance 🔧
+      labels:
+        - chore
     - title: Other Changes
       labels:
         - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ Automated tests only cover `src/model/`. After implementing a change that affect
 - Beta release: run `release-beta.yml` on the equivalent of the develop branch, still with a typed-in explicit version (e.g. `1.2.0-beta.1`) since beta versions don't map to a bump level → updates manifest-beta.json, pushes to develop, and tags it → automatically opens a PR from a branch that cherry-picks that change onto master (merging is manual) → creates a GitHub Release marked as prerelease. Because BRAT reads `manifest.json` from the release assets, the build step copies `manifest-beta.json` over `manifest.json` before packaging, so BRAT sees the beta version.
 - `versions.json` maps plugin versions to the minimum supported Obsidian version; `release.yml` appends the new version automatically using manifest.json's `minAppVersion`, so this file no longer needs manual upkeep.
 
+GitHub Release notes are auto-generated from PR labels according to `.github/release.yml`. Every PR should be labeled with one of `breaking-change`, `enhancement`, `bug`, `documentation`, or `chore` (Dependabot PRs get `dependencies` automatically). Unlabeled PRs fall into "Other Changes".
+
 ## Notes
 
 - Unlike the common practice of using the `window.moment` that Obsidian itself provides, this plugin imports `moment` directly as an npm dependency (it's not listed in `esbuild.config.mjs`'s `external` either) and bundles it itself with esbuild. Don't write code that assumes Obsidian's bundled moment.


### PR DESCRIPTION
## Summary
- Expand `.github/release.yml`'s changelog categories from just Breaking Changes / New Features / Other Changes to also include Bug Fixes, Documentation, Dependency Updates, and Maintenance, so release notes separate dependency bumps and internal maintenance from user-facing changes.
- Document in `CLAUDE.md`'s Release flow section that release notes are auto-generated from PR labels, and that every PR should carry one of `breaking-change`, `enhancement`, `bug`, `documentation`, or `chore` (Dependabot PRs get `dependencies` automatically); unlabeled PRs fall into "Other Changes".
- Created the two missing repository labels used by the new categories: `breaking-change` and `chore`. `enhancement`, `bug`, `documentation`, `dependencies` already existed as GitHub defaults / prior labels.

## Test plan
- [ ] Not applicable — no source code changes, only `.github/release.yml` config and `CLAUDE.md` docs.
- [ ] On the next release, confirm the categorized sections appear correctly in the auto-generated release notes once PRs carry the new labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)