### PR TITLE
CI: verify merge results on master and typecheck before releasing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,14 @@
 name: CI
 
+# Also run on pushes to master: PR checks only validate a branch against the
+# base it was opened against, not the actual merge result, and nothing else
+# verifies master after a merge. That gap let #317 and #318 each pass PR CI
+# individually while their combined merge broke `tsc --noEmit` on master,
+# shipping broken code in release 1.2.0 (hotfixed in #320 / 1.2.1).
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches: [master]
 
 env:
   # The electron package is only used for its TypeScript types; skip the
@@ -34,13 +41,20 @@ jobs:
         run: node scripts/check-versions.mjs
 
       - name: Lint with ESLint
-        continue-on-error: true
+        # On pull_request, let this step pass through failures so reviewdog
+        # (below) reports them as inline PR review comments instead. On
+        # push (master), there is no PR to annotate, so let this step fail
+        # the workflow directly or ESLint errors would go unnoticed.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: |
           npx eslint
 
       - name: Annotate ESLint results
         uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
-        if: always()
+        # reviewdog's github-pr-review reporter only works on pull_request
+        # events; run it regardless of the eslint step's outcome so it still
+        # annotates when ESLint found problems, but skip it entirely on push.
+        if: always() && github.event_name == 'pull_request'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type check
+        run: |
+          npx tsc --noEmit --pretty
+          npx svelte-check
+
       - name: Test
         run: npm run test
 


### PR DESCRIPTION
## Summary

Closes the two gaps that let the #317/#318 semantically-broken auto-merge reach master and ship in 1.2.0 (hotfixed in #320 / 1.2.1):

1. **`pr.yml` now also runs on pushes to master.** PR checks validate a branch against the base it was opened against — never the actual merge result. On push events, the eslint step fails the workflow directly (`continue-on-error` is now conditional) and the reviewdog annotation step is skipped (its `github-pr-review` reporter needs a PR).
2. **`release.yml` gets a Type check step** (`tsc --noEmit` + `svelte-check`) before the test step, as the last line of defense: jest only compiles the model layer and esbuild strips types without checking, so neither catches a type-broken tree.

Not changed: `release-beta.yml` fuses `npm ci && npm run build` into one step with no test stage, so adding a typecheck there needs a small restructure — left as a possible follow-up.

Also worth considering (repo settings, not code): enabling branch protection's "Require branches to be up to date before merging" on master would force PR re-validation after base moves, preventing this class of merge at the source — at the cost of extra update/re-run cycles on parallel PRs.

## Test plan

- YAML syntax validated for both changed workflows
- The exact commands the new steps run pass locally on current master (`tsc --noEmit`, `svelte-check`)
- The push-event behavior will be observable on this PR's own merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)