### PR TITLE
Persist reminder mute state and add bulk mute

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -52,9 +52,19 @@ The reminder will be muted if you do the following:
     - click outside of the notification modal
 - Close the system notification
 
-A muted reminder will not be notified again until
-- you restart the Obsidian app
-- you click muted reminder in [reminder list view](/guide/list-reminders.html)
+A muted reminder is remembered across Obsidian restarts, so it stays muted even after you close and reopen the app (useful on mobile, where the app restarts frequently).
+
+A muted reminder becomes active again if you:
+- click it in [reminder list view](/guide/list-reminders.html), which opens the reminder popup again so you can mark it done or snooze it
+- change the reminder's date/time in the markdown
+
+## Muting all reminders at once
+
+If notifications have piled up (for example, after a vacation), you can mute every currently overdue reminder in one action:
+- Click `Mute all reminders…` at the bottom of a notification popup.
+- Run `Mute all current reminders` from the command palette.
+
+This mutes every reminder that is currently overdue, the same way [muting a single reminder](#mute-notification) does. Unlike [pausing notifications](#pausing-notifications-temporarily-do-not-disturb), which is temporary and lets overdue reminders notify you again once it ends, mute-all is permanent per reminder: each muted reminder stays muted (and survives restarts) until you interact with it as described above.
 
 ## Pausing notifications temporarily (do not disturb)
 

--- a/src/model/reminder.test.ts
+++ b/src/model/reminder.test.ts
@@ -1,6 +1,6 @@
 import moment from "moment";
 import { DateTime, Time } from "./time";
-import { Reminder, groupReminders } from "./reminder";
+import { Reminder, Reminders, groupReminders } from "./reminder";
 import type { DateDisplayFormat, GroupedReminder } from "./reminder";
 
 describe("Reminder", (): void => {
@@ -93,5 +93,52 @@ describe("groupReminders()", (): void => {
     const group = groupOf(groups, reminder);
     expect(group?.name).toBe("Overdue");
     expect(group?.isOverdue).toBe(true);
+  });
+});
+
+describe("Reminders#muteExpiredReminders()", (): void => {
+  const reminderTime = Time.parse("09:00");
+
+  function makeReminder(
+    title: string,
+    time: DateTime,
+    muteNotification: boolean = false,
+  ): Reminder {
+    const reminder = new Reminder("file.md", title, time, 0, false);
+    reminder.muteNotification = muteNotification;
+    return reminder;
+  }
+
+  test("mutes expired reminders and leaves non-expired reminders unmuted", (): void => {
+    const reminders = new Reminders(() => {});
+    const expired = makeReminder("expired", DateTime.now().add(-1, "hours"));
+    const future = makeReminder("future", DateTime.now().add(1, "days"));
+    reminders.replaceFile("file.md", [expired, future]);
+
+    const count = reminders.muteExpiredReminders(reminderTime);
+
+    expect(count).toBe(1);
+    expect(expired.muteNotification).toBe(true);
+    expect(future.muteNotification).toBe(false);
+  });
+
+  test("returns only the count of newly muted reminders, not already-muted ones", (): void => {
+    const reminders = new Reminders(() => {});
+    const alreadyMuted = makeReminder(
+      "already-muted",
+      DateTime.now().add(-2, "hours"),
+      true,
+    );
+    const newlyMuted = makeReminder(
+      "newly-muted",
+      DateTime.now().add(-1, "hours"),
+    );
+    reminders.replaceFile("file.md", [alreadyMuted, newlyMuted]);
+
+    const count = reminders.muteExpiredReminders(reminderTime);
+
+    expect(count).toBe(1);
+    expect(alreadyMuted.muteNotification).toBe(true);
+    expect(newlyMuted.muteNotification).toBe(true);
   });
 });

--- a/src/model/reminder.ts
+++ b/src/model/reminder.ts
@@ -77,6 +77,26 @@ export class Reminders {
     return result;
   }
 
+  /**
+   * Mutes every currently expired reminder (bulk mute, #220), so the
+   * notification storm after a long absence can be stopped in one action.
+   * Mirrors the single-reminder mute path: it only flips `muteNotification`
+   * and does not call `onChange()`, leaving UI reload to the caller.
+   *
+   * @returns the number of reminders that were newly muted (already-muted
+   * expired reminders don't count).
+   */
+  public muteExpiredReminders(defaultTime: Time): number {
+    let count = 0;
+    for (const reminder of this.getExpiredReminders(defaultTime)) {
+      if (!reminder.muteNotification) {
+        reminder.muteNotification = true;
+        count++;
+      }
+    }
+    return count;
+  }
+
   public byDate(date: DateTime) {
     return this.reminders.filter(
       (reminder) => reminder.time.toYYYYMMDD() === date.toYYYYMMDD(),

--- a/src/plugin/commands/index.ts
+++ b/src/plugin/commands/index.ts
@@ -1,5 +1,6 @@
 import type ReminderPlugin from "main";
 import { MarkdownView } from "obsidian";
+import { muteAllReminders } from "./mute-all-reminders";
 import { pauseNotifications } from "./pause-notifications";
 import { resumeNotifications } from "./resume-notifications";
 import { scanReminders } from "./scan-reminders";
@@ -88,6 +89,14 @@ export function registerCommands(plugin: ReminderPlugin) {
     name: "Resume reminder notifications",
     checkCallback: (checking: boolean) => {
       return resumeNotifications(checking, plugin);
+    },
+  });
+
+  plugin.addCommand({
+    id: "mute-all-reminders",
+    name: "Mute all current reminders",
+    checkCallback: (checking: boolean) => {
+      return muteAllReminders(checking, plugin);
     },
   });
 }

--- a/src/plugin/commands/mute-all-reminders.ts
+++ b/src/plugin/commands/mute-all-reminders.ts
@@ -1,0 +1,27 @@
+import type ReminderPlugin from "main";
+import { Notice } from "obsidian";
+
+export function muteAllReminders(
+  checking: boolean,
+  plugin: ReminderPlugin,
+): boolean {
+  const expired = plugin.reminders.getExpiredReminders(
+    plugin.settings.reminderTime.value,
+  );
+  // Only available when the command would actually mute something: if every
+  // expired reminder is already muted, running it would just report
+  // "Muted 0 reminders".
+  if (!expired.some((r) => !r.muteNotification)) {
+    return false;
+  }
+  if (checking) {
+    return true;
+  }
+  const count = plugin.reminders.muteExpiredReminders(
+    plugin.settings.reminderTime.value,
+  );
+  plugin.ui.reload(true);
+  void plugin.data.save(true);
+  new Notice(`Muted ${count} reminder${count === 1 ? "" : "s"}`);
+  return true;
+}

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -8,6 +8,7 @@ interface ReminderData {
   title: string;
   time: string;
   rowNumber: number;
+  muted?: boolean;
 }
 
 /**
@@ -92,16 +93,17 @@ export class PluginData {
         }
         this.reminders.replaceFile(
           filePath,
-          remindersInFile.map(
-            (d) =>
-              new Reminder(
-                filePath,
-                d.title,
-                DateTime.parse(d.time),
-                d.rowNumber,
-                false,
-              ),
-          ),
+          remindersInFile.map((d) => {
+            const reminder = new Reminder(
+              filePath,
+              d.title,
+              DateTime.parse(d.time),
+              d.rowNumber,
+              false,
+            );
+            reminder.muteNotification = d.muted ?? false;
+            return reminder;
+          }),
         );
       });
     }
@@ -126,6 +128,7 @@ export class PluginData {
         title: rr.title,
         time: rr.time.toString(),
         rowNumber: rr.rowNumber,
+        muted: rr.muteNotification,
       }));
     });
     const settings: Record<string, unknown> = {};

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -5,6 +5,7 @@ import type { Reminder } from "model/reminder";
 import {
   App,
   MarkdownView,
+  Notice,
   Platform,
   PluginSettingTab,
   TFile,
@@ -128,6 +129,7 @@ export class ReminderPluginUI {
     onMute: () => void,
     onOpenFile: () => void,
     onPauseAllNotifications: () => void,
+    onMuteAll: () => void,
   ) {
     this.reminderModal.show(
       reminder,
@@ -136,6 +138,7 @@ export class ReminderPluginUI {
       onMute,
       onOpenFile,
       onPauseAllNotifications,
+      onMuteAll,
     );
   }
 
@@ -215,6 +218,7 @@ export class ReminderPluginUI {
         console.debug("Mute");
         reminder.muteNotification = true;
         this.reload(true);
+        void this.plugin.data.save(true);
       },
       () => {
         console.debug("Open");
@@ -228,6 +232,24 @@ export class ReminderPluginUI {
         // individual reminders, so it re-fires once the pause ends.
         reminder.muteNotification = false;
         showPauseDurationChooser(this.plugin);
+      },
+      () => {
+        console.debug("Mute all reminders");
+        // +1 for the currently displayed reminder: it was already flagged
+        // muted at display time (top of `showReminder()`), so
+        // `muteExpiredReminders()` never counts it as newly muted, but from
+        // the user's perspective this action is what mutes it.
+        const count =
+          this.plugin.reminders.muteExpiredReminders(
+            this.plugin.settings.reminderTime.value,
+          ) + 1;
+        // Already covered by muteExpiredReminders() in the common case, but
+        // set explicitly to stay correct even if this reminder's expiry
+        // check races with the bulk mute above.
+        reminder.muteNotification = true;
+        this.reload(true);
+        void this.plugin.data.save(true);
+        new Notice(`Muted ${count} reminder${count === 1 ? "" : "s"}`);
       },
     );
   }

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -21,6 +21,7 @@ export class ReminderModal {
     onMute: () => void,
     onOpenFile: () => void,
     onPauseAllNotifications: () => void,
+    onMuteAll: () => void,
   ) {
     if (!this.isSystemNotification()) {
       this.showBuiltinReminder(
@@ -30,6 +31,7 @@ export class ReminderModal {
         onMute,
         onOpenFile,
         onPauseAllNotifications,
+        onMuteAll,
       );
       return;
     }
@@ -47,6 +49,7 @@ export class ReminderModal {
         onMute,
         onOpenFile,
         onPauseAllNotifications,
+        onMuteAll,
       );
     }
     this.showSystemNotification(
@@ -56,6 +59,7 @@ export class ReminderModal {
       onMute,
       onOpenFile,
       onPauseAllNotifications,
+      onMuteAll,
       showBothSurfaces,
     );
   }
@@ -67,6 +71,7 @@ export class ReminderModal {
     onMute: () => void,
     onOpenFile: () => void,
     onPauseAllNotifications: () => void,
+    onMuteAll: () => void,
     alertOnly: boolean,
   ) {
     const Notification = (electron as any).remote.Notification;
@@ -88,6 +93,7 @@ export class ReminderModal {
           onMute,
           onOpenFile,
           onPauseAllNotifications,
+          onMuteAll,
         );
       }
     });
@@ -124,6 +130,7 @@ export class ReminderModal {
     onCancel: () => void,
     onOpenFile: () => void,
     onPauseAllNotifications: () => void,
+    onMuteAll: () => void,
   ) {
     new NotificationModal(
       this.app,
@@ -134,6 +141,7 @@ export class ReminderModal {
       onCancel,
       onOpenFile,
       onPauseAllNotifications,
+      onMuteAll,
     ).open();
   }
 
@@ -156,6 +164,11 @@ class NotificationModal extends Modal {
   // mutes the reminder) is skipped, letting the reminder re-fire once the
   // pause ends.
   private pausingAll: boolean = false;
+  // Set when the modal is closed via "Mute all reminders...". Like
+  // `pausingAll`, this takes precedence over `canceled` in `onClose()` so
+  // `onCancel` (single mute) is skipped -- muting all already covers this
+  // reminder, so the single mute would be redundant.
+  private mutingAll: boolean = false;
 
   constructor(
     app: App,
@@ -166,6 +179,7 @@ class NotificationModal extends Modal {
     private onCancel: () => void,
     private onOpenFile: () => void,
     private onPauseAllNotifications: () => void,
+    private onMuteAll: () => void,
   ) {
     super(app);
   }
@@ -205,6 +219,11 @@ class NotificationModal extends Modal {
           this.onPauseAllNotifications();
           this.close();
         },
+        onMuteAll: () => {
+          this.mutingAll = true;
+          this.onMuteAll();
+          this.close();
+        },
       },
     });
   }
@@ -218,6 +237,9 @@ class NotificationModal extends Modal {
     if (this.pausingAll) {
       // Skip `onCancel` (mute): pausing suppresses notifications globally
       // without muting this specific reminder.
+    } else if (this.mutingAll) {
+      // Skip `onCancel` (single mute): muting all already covers this
+      // reminder.
     } else if (this.canceled) {
       this.onCancel();
     }

--- a/src/ui/Reminder.svelte
+++ b/src/ui/Reminder.svelte
@@ -11,6 +11,7 @@
   export let onOpenFile: () => void;
   export let onMute: () => void;
   export let onPauseAllNotifications: () => void;
+  export let onMuteAll: () => void;
   // Do not set initial value so that svelte can render the placeholder `Remind Me Later`.
   let selectedIndex: number;
   export let laters: Array<Later> = [];
@@ -61,9 +62,14 @@
       {/each}
     </select>
   </div>
-  <button class="reminder-pause-all" on:click={onPauseAllNotifications}>
-    Pause all notifications…
-  </button>
+  <div class="reminder-secondary-actions">
+    <button class="reminder-footer-action" on:click={onPauseAllNotifications}>
+      Pause all notifications…
+    </button>
+    <button class="reminder-footer-action" on:click={onMuteAll}>
+      Mute all reminders…
+    </button>
+  </div>
 </main>
 
 <style>
@@ -95,7 +101,13 @@
     font-size: 14px;
   }
 
-  .reminder-pause-all {
+  .reminder-secondary-actions {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .reminder-footer-action {
     display: block;
     margin-top: 0.75rem;
     padding: 0;
@@ -108,7 +120,7 @@
     font-size: 12px;
   }
 
-  .reminder-pause-all:hover {
+  .reminder-footer-action:hover {
     color: var(--text-muted);
   }
 </style>


### PR DESCRIPTION
## Summary

Fixes two long-standing complaints about muting reminders:

- **Persist per-reminder mute state (#183).** `Reminder.muteNotification` was memory-only, so every Obsidian restart (frequent on mobile) reset all mutes and re-notified every overdue reminder. The mute flag is now serialized in the plugin data file and restored on load; the existing key-based migration in `Reminders.replaceFile()` carries it across the post-load vault rescan. Muting a reminder now also force-saves plugin data so the state hits disk immediately.
- **Bulk mute (#220).** A new `Mute all reminders…` link at the bottom of the notification popup and a `Mute all current reminders` command mute every currently overdue reminder in one action, stopping the popup storm after a long absence (the notification worker checks the mute flag before showing each queued popup, so the remaining popups are suppressed). The command is only available while at least one unmuted overdue reminder exists.

## Changes

- `src/model/reminder.ts`: new `Reminders.muteExpiredReminders(defaultTime): number` (returns the count of newly muted reminders), with unit tests.
- `src/plugin/data.ts`: `muted` field added to the persisted per-reminder data; saved and restored.
- `src/plugin/ui/index.ts` / `src/plugin/ui/reminder.ts` / `src/ui/Reminder.svelte`: mute now persists immediately; `onMuteAll` callback threaded through the modal; new footer link alongside `Pause all notifications…`.
- `src/plugin/commands/mute-all-reminders.ts`: new command.
- `docs/src/guide/notification.md`: mute now survives restarts; new "Muting all reminders at once" section.

Since a restart no longer clears mutes, a muted reminder becomes active again by snoozing it from the reminder list popup, or by editing its date/time in the markdown (documented).

## Testing

- `mise run main:lint:fix` (eslint + tsc --noEmit + svelte-check): clean.
- `mise run main:test`: 13 suites / 140 tests passing (includes new tests for `muteExpiredReminders`).
- Production build succeeds.
- Manual verification in a test vault is in progress; results will be posted as a comment on this PR.

Closes #183
Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)