### PR TITLE
Show reminder times as clickable pills in the markdown editor

### DIFF
--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -63,6 +63,16 @@ Reminder format for generated reminder by calendar popup.
   - [Tasks plugin format](/guide/interop-tasks.html)
   - [Kanban plugin format](/guide/interop-kanban.html)
 
+## Show reminder pills in editor
+
+Render each reminder's time as a clickable pill (⏰) in [Live Preview](https://help.obsidian.md/Editing+and+formatting/Editing+modes). Clicking a pill opens the date/time chooser to change it, only available on desktop.
+
+- Type: `boolean`
+- Values:
+  - ON: Reminder times are shown as clickable pills in Live Preview (default)
+  - OFF: Reminder times are shown as raw text
+- Default: ON
+
 ## Excluded files/folders
 
 Reminders in these files/folders are ignored when scanning the vault, and any reminders already found in them are removed.

--- a/src/model/content.ts
+++ b/src/model/content.ts
@@ -15,7 +15,7 @@ export class Content {
   }
 
   public getReminders(doneOnly: boolean = true): Array<Reminder> {
-    const reminders = parseReminder(this.doc);
+    const reminders = parseReminder(this.doc).map((span) => span.reminder);
     if (!doneOnly) {
       return reminders;
     }

--- a/src/model/format/index.ts
+++ b/src/model/format/index.ts
@@ -4,6 +4,7 @@ import type {
   ReminderEdit,
   ReminderFormat,
   ReminderFormatConfig,
+  ReminderSpan,
 } from "./reminder-base";
 import { CompositeReminderFormat } from "./reminder-base";
 import { DefaultReminderFormat } from "./reminder-default";
@@ -23,9 +24,9 @@ export class ReminderFormatType {
   ) {}
 }
 
-export type { ReminderFormat, ReminderEdit };
+export type { ReminderFormat, ReminderEdit, ReminderSpan };
 
-export function parseReminder(doc: MarkdownDocument): Array<Reminder> {
+export function parseReminder(doc: MarkdownDocument): Array<ReminderSpan> {
   return REMINDER_FORMAT.parse(doc);
 }
 

--- a/src/model/format/reminder-base.test.ts
+++ b/src/model/format/reminder-base.test.ts
@@ -9,11 +9,13 @@ export class ReminderFormatTestUtil<T extends ReminderFormat> {
     inputMarkdown,
     expectedTime,
     expectedTitle,
+    expectedSpan,
     configFunc,
   }: {
     inputMarkdown: string;
     expectedTime: string;
     expectedTitle: string;
+    expectedSpan?: { start: number; end: number };
     configFunc?: (config: ReminderFormatConfig) => void;
   }) {
     const sut = this.creator();
@@ -23,10 +25,15 @@ export class ReminderFormatTestUtil<T extends ReminderFormat> {
     }
     sut.setConfig(config);
 
-    const reminders = sut.parse(new MarkdownDocument("file", inputMarkdown));
-    const reminder = reminders![0]!;
-    expect(reminder.time.toString()).toBe(expectedTime);
-    expect(reminder.title).toBe(expectedTitle);
+    const spans = sut.parse(new MarkdownDocument("file", inputMarkdown));
+    const span = spans![0]!;
+    expect(span.reminder.time.toString()).toBe(expectedTime);
+    expect(span.reminder.title).toBe(expectedTitle);
+    if (expectedSpan) {
+      expect({ start: span.columnStart, end: span.columnEnd }).toEqual(
+        expectedSpan,
+      );
+    }
   }
 
   async testModify({
@@ -48,8 +55,8 @@ export class ReminderFormatTestUtil<T extends ReminderFormat> {
     }
     sut.setConfig(config);
 
-    const reminders = sut.parse(doc);
-    await sut.modify(doc, reminders![0]!, edit);
+    const spans = sut.parse(doc);
+    await sut.modify(doc, spans![0]!.reminder, edit);
     expect(doc.toMarkdown()).toBe(expectedMarkdown);
   }
 }

--- a/src/model/format/reminder-base.ts
+++ b/src/model/format/reminder-base.ts
@@ -27,6 +27,15 @@ export interface ReminderModel {
    * this is used for decision of caret position after inserting reminder.
    */
   getEndOfTimeTextIndex(): number;
+
+  /**
+   * Compute the span `[start, end)` of the reminder time text, expressed as
+   * 0-based UTF-16 column indices within the todo *body* (i.e. before the
+   * todo header, such as `- [ ] `, is prepended). Callers that need the span
+   * within the full line must add `todo.getHeaderLength()` themselves (see
+   * `TodoBasedReminderFormat.parse`).
+   */
+  computeSpan(): { start: number; end: number };
 }
 
 export class ReminderFormatParameterKey<T> {
@@ -97,12 +106,23 @@ export class ReminderFormatConfig {
   }
 }
 
+/**
+ * A parsed reminder paired with the column span (within the full line text)
+ * of the reminder time text it was parsed from, e.g. `(@2021-09-14)`,
+ * `📅 2021-09-08`, or `@{2021-09-08} @@{12:15}`.
+ */
+export type ReminderSpan = {
+  reminder: Reminder;
+  columnStart: number;
+  columnEnd: number;
+};
+
 export interface ReminderFormat {
   setConfig(config: ReminderFormatConfig): void;
   /**
    * Parse given line if possible.
    */
-  parse(doc: MarkdownDocument): Array<Reminder> | null;
+  parse(doc: MarkdownDocument): Array<ReminderSpan> | null;
   /**
    * Modify the given line if possible.
    *
@@ -140,7 +160,7 @@ export abstract class TodoBasedReminderFormat<
     this.config = config;
   }
 
-  parse(doc: MarkdownDocument): Reminder[] {
+  parse(doc: MarkdownDocument): ReminderSpan[] {
     return doc
       .getTodos()
       .map((todo) => {
@@ -156,15 +176,22 @@ export abstract class TodoBasedReminderFormat<
         if (time == null) {
           return null;
         }
-        return new Reminder(
+        const reminder = new Reminder(
           doc.file,
           title,
           time,
           todo.lineIndex,
           todo.isChecked(),
         );
+        const span = parsed.computeSpan();
+        const headerLength = todo.getHeaderLength();
+        return {
+          reminder,
+          columnStart: span.start + headerLength,
+          columnEnd: span.end + headerLength,
+        };
       })
-      .filter((reminder): reminder is Reminder => reminder != null);
+      .filter((span): span is ReminderSpan => span != null);
   }
 
   async modify(
@@ -275,8 +302,8 @@ export class CompositeReminderFormat implements ReminderFormat {
     this.syncConfig();
   }
 
-  parse(doc: MarkdownDocument): Reminder[] {
-    const reminders: Array<Reminder> = [];
+  parse(doc: MarkdownDocument): ReminderSpan[] {
+    const reminders: Array<ReminderSpan> = [];
     for (const format of this.formats) {
       const parsed = format.parse(doc);
       if (parsed == null) {

--- a/src/model/format/reminder-default.test.ts
+++ b/src/model/format/reminder-default.test.ts
@@ -34,6 +34,7 @@ describe("DefaultReminderFormat", (): void => {
       inputMarkdown: "- [ ] Task1 (@2021-09-14)",
       expectedTime: "2021-09-14",
       expectedTitle: "Task1",
+      expectedSpan: { start: 12, end: 12 + 13 },
       configFunc: (config) => {
         config.setParameterValue(
           ReminderFormatParameterKey.linkDatesToDailyNotes,
@@ -45,6 +46,7 @@ describe("DefaultReminderFormat", (): void => {
       inputMarkdown: "- [ ] Task1 (@2021-09-14 10:00)",
       expectedTime: "2021-09-14 10:00",
       expectedTitle: "Task1",
+      expectedSpan: { start: 12, end: 12 + 19 },
       configFunc: (config) => {
         config.setParameterValue(
           ReminderFormatParameterKey.linkDatesToDailyNotes,
@@ -58,6 +60,7 @@ describe("DefaultReminderFormat", (): void => {
       inputMarkdown: "- [ ] Task1 (@[[2021-09-14]] 10:00)",
       expectedTime: "2021-09-14 10:00",
       expectedTitle: "Task1",
+      expectedSpan: { start: 12, end: 35 },
       configFunc: (config) => {
         config.setParameterValue(
           ReminderFormatParameterKey.linkDatesToDailyNotes,
@@ -69,6 +72,7 @@ describe("DefaultReminderFormat", (): void => {
       inputMarkdown: "- [ ] Task1 (@[[2021-09-14]])",
       expectedTime: "2021-09-14",
       expectedTitle: "Task1",
+      expectedSpan: { start: 12, end: 29 },
       configFunc: (config) => {
         config.setParameterValue(
           ReminderFormatParameterKey.linkDatesToDailyNotes,
@@ -116,6 +120,9 @@ describe("DefaultReminderFormat", (): void => {
         inputMarkdown: "- [ ] Task1 (@2021-09-14 🔁every day)",
         expectedTime: "2021-09-14",
         expectedTitle: "Task1",
+        // "- [ ] " (6) + "Task1 " (6) = 12; "(@2021-09-14 🔁every day)" is 25
+        // UTF-16 units long (🔁 is a surrogate pair, 2 units).
+        expectedSpan: { start: 12, end: 12 + 25 },
       });
     });
     test("datetime with recurrence", (): void => {
@@ -303,8 +310,8 @@ describe("DefaultReminderFormat", (): void => {
       const config = new ReminderFormatConfig();
       sut.setConfig(config);
 
-      let reminders = sut.parse(doc);
-      await sut.modify(doc, reminders[0]!, {
+      let spans = sut.parse(doc);
+      await sut.modify(doc, spans[0]!.reminder, {
         time: new DateTime(moment("2021-09-12 15:00"), true),
       });
       expect(doc.toMarkdown()).toBe(
@@ -315,8 +322,8 @@ describe("DefaultReminderFormat", (): void => {
         ReminderFormatParameterKey.now,
         new DateTime(moment("2021-09-13 08:00"), true),
       );
-      reminders = sut.parse(doc);
-      await sut.modify(doc, reminders[0]!, { checked: true });
+      spans = sut.parse(doc);
+      await sut.modify(doc, spans[0]!.reminder, { checked: true });
       expect(doc.toMarkdown()).toBe(
         `- [ ] Task (@2021-09-14 15:00 🔁every day)
 - [x] Task (@2021-09-12 15:00 🔁every day)`,
@@ -332,8 +339,8 @@ describe("DefaultReminderFormat", (): void => {
       const config = new ReminderFormatConfig();
       sut.setConfig(config);
 
-      let reminders = sut.parse(doc);
-      await sut.modify(doc, reminders[0]!, {
+      let spans = sut.parse(doc);
+      await sut.modify(doc, spans[0]!.reminder, {
         time: new DateTime(moment("2021-09-13"), false),
       });
       expect(doc.toMarkdown()).toBe("- [ ] Task (@2021-09-13 🔁every day)");
@@ -342,8 +349,8 @@ describe("DefaultReminderFormat", (): void => {
         ReminderFormatParameterKey.now,
         new DateTime(moment("2021-09-13"), true),
       );
-      reminders = sut.parse(doc);
-      await sut.modify(doc, reminders[0]!, { checked: true });
+      spans = sut.parse(doc);
+      await sut.modify(doc, spans[0]!.reminder, { checked: true });
       expect(doc.toMarkdown()).toBe(
         `- [ ] Task (@2021-09-14 🔁every day)
 - [x] Task (@2021-09-13 🔁every day)`,

--- a/src/model/format/reminder-default.ts
+++ b/src/model/format/reminder-default.ts
@@ -82,23 +82,45 @@ export class DefaultReminderModel implements ReminderModel {
   getEndOfTimeTextIndex(): number {
     return this.toMarkdown().length - this.title2.length;
   }
+  computeSpan(): { start: number; end: number } {
+    const start = this.title1.length;
+    const groupText = this.computeGroupText();
+    return { start, end: start + groupText.length };
+  }
   toMarkdown(): string {
+    return `${this.title1}${this.computeGroupText()}${this.title2}`;
+  }
+
+  /**
+   * Render the whole `(@...)` group text, including the recurrence segment
+   * (if any) and the daily-note-link rendering (if enabled). This is the
+   * single source of truth for both `toMarkdown()` and `computeSpan()`.
+   */
+  private computeGroupText(): string {
     const timeText =
       this.recurrence !== null
         ? `${this.time} ${DefaultReminderModel.recurrenceSymbol}${this.recurrence}`
         : this.time;
-    const result = `${this.title1}(@${timeText})${this.title2}`;
+    return `(@${this.renderTimeText(timeText)})`;
+  }
+
+  /**
+   * Apply the daily-note-link rendering to the time text only (not the
+   * whole line), so that a date-like string in the title is never
+   * mistakenly turned into a link.
+   */
+  private renderTimeText(timeText: string): string {
     if (!this.linkDatesToDailyNotes) {
-      return result;
+      return timeText;
     }
 
     const time = DATE_TIME_FORMATTER.parse(this.time);
     if (!time) {
-      return result;
+      return timeText;
     }
 
     const date = DATE_TIME_FORMATTER.toString(time.clone(false));
-    return result.replace(date, `[[${date}]]`);
+    return timeText.replace(date, `[[${date}]]`);
   }
 
   clone(): DefaultReminderModel {

--- a/src/model/format/reminder-kanban-plugin.test.ts
+++ b/src/model/format/reminder-kanban-plugin.test.ts
@@ -131,20 +131,36 @@ describe("KanbanReminderFormat", (): void => {
     expect(parsed!.time.toString()).toBe("2021-09-08");
     expect(parsed!.getTime()!.toString()).toBe("2021-09-08");
     expect(parsed!.title).toBe("task1");
+    // computeSpan(): "task1 " is 6 chars, "@{2021-09-08}" is 13 chars.
+    const span = parsed!.computeSpan();
+    expect(span.start).toBe(6);
+    expect(span.end).toBe(19);
   });
   test("parse() with time", (): void => {
     const parsed = KanbanReminderModel.parse("task1 @{2021-09-08} @@{12:15}");
     expect(parsed!.time.toString()).toBe("2021-09-08 12:15");
     expect(parsed!.title).toBe("task1");
+    // computeSpan(): "task1 " (6) + "@{2021-09-08} @@{12:15}" (23) => end 29.
+    const span = parsed!.computeSpan();
+    expect(span.start).toBe(6);
+    expect(span.end).toBe(29);
   });
   test("setDate() simple", (): void => {
     const parsed = KanbanReminderModel.parse("task1 @{2021-09-07}");
     parsed!.setTime(new DateTime(moment("2021-09-08"), false));
     expect(parsed!.toMarkdown()).toBe("task1 @{2021-09-08}");
+    // computeSpan() after update: same shape as parse() without time.
+    const span = parsed!.computeSpan();
+    expect(span.start).toBe(6);
+    expect(span.end).toBe(19);
   });
   test("setDate() with time", (): void => {
     const parsed = KanbanReminderModel.parse("task1 @{2021-09-07}");
     parsed!.setTime(new DateTime(moment("2021-09-08 10:00"), true));
     expect(parsed!.toMarkdown()).toBe("task1 @{2021-09-08} @@{10:00}");
+    // "task1 " (6) + "@{2021-09-08} @@{10:00}" (23) => end 29.
+    const span = parsed!.computeSpan();
+    expect(span.start).toBe(6);
+    expect(span.end).toBe(29);
   });
 });

--- a/src/model/format/reminder-kanban-plugin.ts
+++ b/src/model/format/reminder-kanban-plugin.ts
@@ -196,6 +196,15 @@ export class KanbanReminderModel implements ReminderModel {
     return this.toMarkdown().length;
   }
 
+  computeSpan(): { start: number; end: number } {
+    // toMarkdown() = `${title.trim()} ${formatted time}`, so the time text
+    // starts right after "title.trim() " (one separating space) and runs to
+    // the end of the markdown.
+    const start = this.title.trim().length + 1;
+    const end = start + KanbanDateTimeFormat.instance.format(this.time).length;
+    return { start, end };
+  }
+
   toMarkdown(): string {
     return `${this.title.trim()} ${KanbanDateTimeFormat.instance.format(this.time)}`;
   }

--- a/src/model/format/reminder-tasks-plugin.test.ts
+++ b/src/model/format/reminder-tasks-plugin.test.ts
@@ -18,6 +18,12 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.getTitle()).toBe("this is a title");
     expect(parsed.getTime()!.toString()).toBe("2021-09-08");
     expect(parsed.getDoneDate()!.toString()).toBe("2021-08-31");
+    // "this is a title " (16) + "🔁 every hour " (14, 🔁 is a UTF-16
+    // surrogate pair) = 30 chars before "📅"; the span covers "📅 2021-09-08"
+    // (13 chars), trimmed of the trailing separator space before "✅".
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(30);
+    expect(span.end).toBe(43);
   });
   test("parse() - due date with time part", (): void => {
     const parsed = TasksPluginReminderModel.parse("task 📅 2021-09-16 10:00");
@@ -49,6 +55,9 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.toMarkdown()).toBe(
       "ABC 🔁 every hour 📅 2021-09-08 ✅ 2021-08-31",
     );
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(18);
+    expect(span.end).toBe(31);
   });
   test("setTime() - date", (): void => {
     const parsed = TasksPluginReminderModel.parse(
@@ -59,6 +68,9 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.toMarkdown()).toBe(
       "this is a title 🔁 every hour 📅 2021-09-09 ✅ 2021-08-31",
     );
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(30);
+    expect(span.end).toBe(43);
   });
   test("setTime() - due date with time part", (): void => {
     const parsed = TasksPluginReminderModel.parse(
@@ -79,6 +91,9 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.toMarkdown()).toBe(
       "this is a title 🔁 every hour 📅 XXX ✅ 2021-08-31",
     );
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(30);
+    expect(span.end).toBe(36);
   });
   test("setTime() - append - with space", (): void => {
     const parsed = TasksPluginReminderModel.parse(
@@ -89,6 +104,11 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.toMarkdown()).toBe(
       "this is a title 🔁 every hour ✅ 2021-08-31 📅 2021-09-08",
     );
+    // 📅 is the last token here (no trailing separator), so the span runs to
+    // the very end of the line (verified against `toMarkdown().length`).
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(43);
+    expect(span.end).toBe(56);
   });
   test("setTime() - append - without space", (): void => {
     const parsed = TasksPluginReminderModel.parse(
@@ -99,6 +119,10 @@ describe("TasksPluginReminderLine", (): void => {
     expect(parsed.toMarkdown()).toBe(
       "this is a title 🔁every hour ✅2021-08-31 📅2021-09-08",
     );
+    // 📅 is again the last token, so the span runs to the end of the line.
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(41);
+    expect(span.end).toBe(53);
   });
   test("setTime() - tag after due date is preserved (#141)", (): void => {
     const parsed = TasksPluginReminderModel.parse("Task 📅 2021-09-08 #mytag");
@@ -125,6 +149,10 @@ describe("TasksPluginReminderLine", (): void => {
     parsed.setTime(new DateTime(moment("2021-09-08"), false));
     expect(parsed.getTime()!.toString()).toBe("2021-09-08");
     expect(parsed.toMarkdown()).toBe("this is a title 📅 2021-09-08");
+    // 📅 is the only/last token, so the span covers the full remaining text.
+    const span = parsed.computeSpan();
+    expect(span.start).toBe(16);
+    expect(span.end).toBe(29);
   });
   test("modify() - default", async () => {
     await testModify({
@@ -226,10 +254,10 @@ async function testModify({
   );
   sut.setConfig(config);
 
-  const reminders = sut.parse(doc);
-  if (reminders.length === 0 && expectedMarkdown === undefined) {
+  const spans = sut.parse(doc);
+  if (spans.length === 0 && expectedMarkdown === undefined) {
     return;
   }
-  await sut.modify(doc, reminders[0]!, { checked: true });
+  await sut.modify(doc, spans[0]!.reminder, { checked: true });
   expect(doc.toMarkdown()).toBe(expectedMarkdown);
 }

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -106,6 +106,26 @@ export class TasksPluginReminderModel implements ReminderModel {
     return this.toMarkdown().length;
   }
 
+  computeSpan(): { start: number; end: number } {
+    const symbol = this.getReminderSymbol();
+    const range = this.tokens.rangeOfSymbol(symbol);
+    const token = this.tokens.getToken(symbol);
+    if (range == null || token == null) {
+      return { start: 0, end: 0 };
+    }
+    // `token.text` may carry a trailing separator space that actually
+    // belongs before the *next* token (see `splitBySymbol`); trim it so the
+    // span covers exactly the rendered time text (symbol + value) and
+    // nothing past it. Note this is not simply `range.end - 1`: when the
+    // reminder symbol is the last token in the line, there is no trailing
+    // separator to trim at all.
+    const trimmedTextLength = token.text.replace(/\s+$/, "").length;
+    return {
+      start: range.start,
+      end: range.start + token.symbol.length + trimmedTextLength,
+    };
+  }
+
   toMarkdown(): string {
     return this.tokens.join();
   }

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -41,6 +41,7 @@ export class Settings {
   strictDateFormat: SettingModel<boolean, boolean>;
   autoCompleteTrigger: SettingModel<string, string>;
   convertNonTaskLines: SettingModel<boolean, boolean>;
+  editorReminderDisplay: SettingModel<boolean, boolean>;
   primaryFormat: SettingModel<string, ReminderFormatType>;
   excludedPaths: SettingModel<string, Array<string>>;
   useCustomEmojiForTasksPlugin: SettingModel<boolean, boolean>;
@@ -223,6 +224,16 @@ export class Settings {
       .toggle(true)
       .build(new RawSerde());
 
+    this.editorReminderDisplay = this.settings
+      .newSettingBuilder()
+      .key("editorReminderDisplay")
+      .name("Show reminder pills in editor")
+      .desc(
+        "Render each reminder's time as a clickable pill (⏰) in Live Preview. Clicking a pill opens the date/time chooser to change it. Disable to show the raw reminder text instead.",
+      )
+      .toggle(true)
+      .build(new RawSerde());
+
     const primaryFormatBuilder = this.settings
       .newSettingBuilder()
       .key("primaryReminderFormat")
@@ -356,6 +367,7 @@ export class Settings {
         this.autoCompleteTrigger,
         this.convertNonTaskLines,
         this.primaryFormat,
+        this.editorReminderDisplay,
       );
     this.settings.newGroup("File Scanning").addSettings(this.excludedPaths);
     this.settings

--- a/src/plugin/ui/date-chooser-modal.ts
+++ b/src/plugin/ui/date-chooser-modal.ts
@@ -12,6 +12,7 @@ class DateTimeChooserModal extends Modal {
     private onSelect: (value: DateTime) => void,
     private onCancel: () => void,
     private timeStep: number,
+    private initialTime?: DateTime,
   ) {
     super(app);
   }
@@ -35,6 +36,7 @@ class DateTimeChooserModal extends Modal {
         },
         reminders: this.reminders,
         timeStep: this.timeStep,
+        initialTime: this.initialTime,
       },
     });
   }
@@ -57,6 +59,7 @@ export function showDateTimeChooserModal(
   app: App,
   reminders: Reminders,
   timeStep: number = 15,
+  initialTime?: DateTime,
 ): Promise<DateTime> {
   return new Promise((resolve, reject) => {
     const modal = new DateTimeChooserModal(
@@ -65,6 +68,7 @@ export function showDateTimeChooserModal(
       resolve,
       reject,
       timeStep,
+      initialTime,
     );
     modal.open();
   });

--- a/src/plugin/ui/editor-reminder-display/ReminderPill.svelte
+++ b/src/plugin/ui/editor-reminder-display/ReminderPill.svelte
@@ -1,0 +1,55 @@
+<script lang="typescript">
+  import { createEventDispatcher } from "svelte";
+
+  export let label: string;
+  export let title: string;
+
+  const dispatch = createEventDispatcher<{ activate: void }>();
+
+  function handleActivate(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    dispatch("activate");
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      dispatch("activate");
+    }
+  }
+</script>
+
+<span
+  class="reminder-pill"
+  role="button"
+  tabindex="0"
+  {title}
+  on:click={handleActivate}
+  on:keydown={handleKeydown}
+  on:mousedown|preventDefault|stopPropagation
+>
+  {label}
+</span>
+
+<style>
+  .reminder-pill {
+    background: var(--tag-background);
+    border: 1px solid var(--tag-border-color);
+    color: var(--text-normal);
+    border-radius: calc(var(--radius-s) + 4px);
+    padding: 0 6px;
+    display: inline-flex;
+    align-items: center;
+    font-size: 0.95em;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .reminder-pill:hover,
+  .reminder-pill:focus {
+    outline: 2px solid var(--interactive-accent);
+    outline-offset: 1px;
+  }
+</style>

--- a/src/plugin/ui/editor-reminder-display/extension.ts
+++ b/src/plugin/ui/editor-reminder-display/extension.ts
@@ -1,0 +1,191 @@
+import type ReminderPlugin from "main";
+import { parseReminder } from "model/format";
+import { MarkdownDocument } from "model/format/markdown";
+import type { ChangeSet, EditorState, Extension } from "@codemirror/state";
+import { Annotation, RangeSetBuilder, StateField } from "@codemirror/state";
+import type { DecorationSet, ViewUpdate } from "@codemirror/view";
+import { Decoration, EditorView, ViewPlugin } from "@codemirror/view";
+import { editorInfoField, editorLivePreviewField } from "obsidian";
+import { deriveReminderPillSpans } from "./spans";
+import { forceReminderPillRecompute } from "./state-effects";
+import { ReminderPillWidget } from "./pill-widget";
+import type { ReminderPillSpan } from "./types";
+
+/** Debounce window for re-parsing after edits that don't touch a known reminder span. */
+const DEBOUNCE_MS = 300;
+
+/** Carries spans computed by the debounced re-parse across the transaction that applies them. */
+const RecomputedSpans = Annotation.define<ReminderPillSpan[]>();
+
+type FieldState = {
+  decos: DecorationSet;
+  cache: ReminderPillSpan[];
+};
+
+/**
+ * Parses the document for reminders and derives their pill spans.
+ *
+ * Wrapped in a single try/catch: a malformed document (or a bug in the
+ * parser) must never break editing, it should just fall back to showing no
+ * pills.
+ */
+function computeReminderPillSpans(
+  plugin: ReminderPlugin,
+  state: EditorState,
+): ReminderPillSpan[] {
+  try {
+    if (!plugin.settings.editorReminderDisplay.value) {
+      return [];
+    }
+    if (!(state.field(editorLivePreviewField, false) ?? false)) {
+      return [];
+    }
+    const filePath = state.field(editorInfoField, false)?.file?.path ?? "";
+    const md = new MarkdownDocument(filePath, state.doc.toString());
+    return deriveReminderPillSpans(state.doc, parseReminder(md));
+  } catch (e) {
+    console.error("Failed to parse reminders for editor pills.", e);
+    return [];
+  }
+}
+
+function buildDecorations(
+  state: EditorState,
+  spans: ReminderPillSpan[],
+  plugin: ReminderPlugin,
+): DecorationSet {
+  const head = state.selection.main.head;
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const span of spans) {
+    // Hide the pill while the cursor sits inside it, so the raw reminder
+    // text is editable.
+    if (head >= span.from && head <= span.to) {
+      continue;
+    }
+    builder.add(
+      span.from,
+      span.to,
+      Decoration.replace({ widget: new ReminderPillWidget(span, plugin) }),
+    );
+  }
+  return builder.finish();
+}
+
+function mapCache(
+  cache: ReminderPillSpan[],
+  changes: ChangeSet,
+): ReminderPillSpan[] {
+  const mapped: ReminderPillSpan[] = [];
+  for (const span of cache) {
+    const from = changes.mapPos(span.from);
+    const to = changes.mapPos(span.to, 1);
+    if (from < to) {
+      mapped.push({ ...span, from, to });
+    }
+  }
+  return mapped;
+}
+
+function createReminderPillField(plugin: ReminderPlugin) {
+  return StateField.define<FieldState>({
+    create(state) {
+      const cache = computeReminderPillSpans(plugin, state);
+      return { decos: buildDecorations(state, cache, plugin), cache };
+    },
+
+    update(value, tr) {
+      let decos = value.decos.map(tr.changes);
+      let cache = tr.docChanged
+        ? mapCache(value.cache, tr.changes)
+        : value.cache;
+
+      const recomputedSpans = tr.annotation(RecomputedSpans);
+      if (recomputedSpans !== undefined) {
+        cache = recomputedSpans;
+      }
+
+      const touchesCache =
+        tr.docChanged &&
+        cache.some((span) => tr.changes.touchesRange(span.from, span.to));
+      const hasForceEffect = tr.effects.some((e) =>
+        e.is(forceReminderPillRecompute),
+      );
+      // `tr.reconfigured` is set for the transaction Obsidian's
+      // `Workspace.updateOptions()` dispatches to every open editor, which
+      // is how the "Show reminder pills in editor" setting toggle reaches
+      // already-open editors: no view registry needed, just react to CM6's
+      // own configuration-change signal.
+      const needsReparse =
+        touchesCache ||
+        tr.reconfigured ||
+        (hasForceEffect && recomputedSpans === undefined);
+
+      if (needsReparse) {
+        cache = computeReminderPillSpans(plugin, tr.state);
+        decos = buildDecorations(tr.state, cache, plugin);
+        return { decos, cache };
+      }
+
+      const selectionChanged = !tr.startState.selection.eq(tr.state.selection);
+      if (recomputedSpans !== undefined || selectionChanged) {
+        // Either the debounced re-parse just delivered fresh spans, or the
+        // selection moved (which can reveal/hide the pill under the
+        // cursor) — rebuild decorations from the current cache without a
+        // full reparse.
+        decos = buildDecorations(tr.state, cache, plugin);
+      }
+
+      return { decos, cache };
+    },
+
+    provide: (field) => EditorView.decorations.from(field, (v) => v.decos),
+  });
+}
+
+/**
+ * Watches for document changes and, after a quiet period, re-parses the
+ * whole document so reminders added/removed outside any currently known
+ * span are picked up without reparsing on every keystroke. Owns its
+ * debounce timer per editor view and clears it on `destroy()` — there is no
+ * module-level timer or view registry.
+ */
+function createReminderPillViewPlugin(plugin: ReminderPlugin) {
+  return ViewPlugin.fromClass(
+    class {
+      private debounceTimer?: number;
+
+      constructor(private readonly view: EditorView) {}
+
+      update(update: ViewUpdate) {
+        if (!update.docChanged) {
+          return;
+        }
+        if (this.debounceTimer !== undefined) {
+          window.clearTimeout(this.debounceTimer);
+        }
+        this.debounceTimer = window.setTimeout(() => {
+          this.debounceTimer = undefined;
+          const spans = computeReminderPillSpans(plugin, this.view.state);
+          this.view.dispatch({
+            annotations: RecomputedSpans.of(spans),
+            effects: [forceReminderPillRecompute.of()],
+          });
+        }, DEBOUNCE_MS);
+      }
+
+      destroy() {
+        if (this.debounceTimer !== undefined) {
+          window.clearTimeout(this.debounceTimer);
+          this.debounceTimer = undefined;
+        }
+      }
+    },
+  );
+}
+
+export function createReminderPillExtension(plugin: ReminderPlugin): Extension {
+  return [
+    createReminderPillField(plugin),
+    createReminderPillViewPlugin(plugin),
+  ];
+}

--- a/src/plugin/ui/editor-reminder-display/index.ts
+++ b/src/plugin/ui/editor-reminder-display/index.ts
@@ -1,0 +1,1 @@
+export { createReminderPillExtension } from "./extension";

--- a/src/plugin/ui/editor-reminder-display/pill-widget.ts
+++ b/src/plugin/ui/editor-reminder-display/pill-widget.ts
@@ -1,0 +1,175 @@
+import type ReminderPlugin from "main";
+import { modifyReminder, parseReminder } from "model/format";
+import type { ReminderSpan } from "model/format";
+import { MarkdownDocument } from "model/format/markdown";
+import { EditorView, WidgetType } from "@codemirror/view";
+import { editorInfoField } from "obsidian";
+import { showDateTimeChooserModal } from "plugin/ui/date-chooser-modal";
+import { forceReminderPillRecompute } from "./state-effects";
+import type { ReminderPillSpan } from "./types";
+import ReminderPillComponent from "./ReminderPill.svelte";
+
+/** Renders a single reminder's time text as a clickable "⏰ <time>" pill. */
+export class ReminderPillWidget extends WidgetType {
+  private component?: ReminderPillComponent;
+
+  constructor(
+    private readonly span: ReminderPillSpan,
+    private readonly plugin: ReminderPlugin,
+  ) {
+    super();
+  }
+
+  override eq(other: ReminderPillWidget): boolean {
+    // Compare content only, not positions: the click flow re-resolves the
+    // reminder from the widget's current DOM position, so correctness never
+    // depends on the captured span. Ignoring positions lets CodeMirror keep
+    // the DOM of every pill below an unrelated edit instead of tearing it
+    // down and rebuilding it on each decoration rebuild.
+    return (
+      this.span.text === other.span.text &&
+      this.span.reminder.title === other.span.reminder.title
+    );
+  }
+
+  override toDOM(view: EditorView): HTMLElement {
+    const container = document.createElement("span");
+    this.component = new ReminderPillComponent({
+      target: container,
+      props: {
+        label: `⏰ ${this.span.reminder.time.toString()}`,
+        title: `Reminder: ${this.span.reminder.title}`,
+      },
+    });
+    this.component.$on("activate", () => {
+      // Fire-and-forget: this is a user-initiated action from a DOM event
+      // handler, there's nothing to await it against.
+      void this.activate(view, container);
+    });
+    return container;
+  }
+
+  override destroy(): void {
+    this.component?.$destroy();
+    this.component = undefined;
+  }
+
+  override ignoreEvent(): boolean {
+    return false;
+  }
+
+  private async activate(
+    view: EditorView,
+    container: HTMLElement,
+  ): Promise<void> {
+    try {
+      await openChooserAndApplyEdit(view, this.plugin, container);
+    } catch {
+      // The chooser was cancelled (or a genuine failure occurred); either
+      // way there's nothing to recover, leave the document untouched.
+    }
+  }
+}
+
+type ResolvedReminder = {
+  md: MarkdownDocument;
+  span: ReminderSpan;
+};
+
+/**
+ * Re-resolves which reminder the pill at `container` refers to, against the
+ * editor's *current* state.
+ *
+ * The click flow must not trust the `ReminderPillSpan` captured at
+ * decoration-build time: after an edit elsewhere in the document, CodeMirror
+ * only maps decoration positions until the debounced reparse lands, and the
+ * `reminder.rowNumber` inside the captured object is never remapped — acting
+ * on it could rewrite the wrong line. The widget's DOM position is always
+ * current, so parse the current document and pick the reminder on the pill's
+ * own line instead.
+ */
+function resolveReminderAt(
+  view: EditorView,
+  container: HTMLElement,
+): ResolvedReminder | null {
+  if (!view.dom.contains(container)) {
+    // The widget was removed while e.g. the chooser modal was open;
+    // posAtDOM() would throw on a detached node.
+    return null;
+  }
+  const pos = view.posAtDOM(container);
+  const line = view.state.doc.lineAt(pos);
+  const filePath = view.state.field(editorInfoField, false)?.file?.path ?? "";
+  const md = new MarkdownDocument(filePath, view.state.doc.toString());
+  const candidates = parseReminder(md).filter(
+    (span) => span.reminder.rowNumber === line.number - 1,
+  );
+
+  // Pick the span containing `pos`, or the nearest one on the line (a line
+  // normally holds exactly one reminder anyway).
+  let best: ReminderSpan | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const from = line.from + candidate.columnStart;
+    const to = line.from + candidate.columnEnd;
+    const distance =
+      pos >= from && pos <= to
+        ? 0
+        : Math.min(Math.abs(pos - from), Math.abs(pos - to));
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  if (best == null) {
+    return null;
+  }
+  return { md, span: best };
+}
+
+/**
+ * Opens the date/time chooser pre-filled with the reminder's current time,
+ * then rewrites only the reminder's own line with the edited time.
+ *
+ * The reminder is resolved from the pill's DOM position twice: once to seed
+ * the chooser, and again after the modal resolves — the modal can stay open
+ * for a while and the document may change underneath it (e.g. via sync), so
+ * the edit is always applied to the then-current resolution.
+ */
+async function openChooserAndApplyEdit(
+  view: EditorView,
+  plugin: ReminderPlugin,
+  container: HTMLElement,
+): Promise<void> {
+  const initial = resolveReminderAt(view, container);
+  if (initial == null) {
+    return;
+  }
+
+  const chosen = await showDateTimeChooserModal(
+    plugin.app,
+    plugin.reminders,
+    plugin.settings.reminderTimeStep.value,
+    initial.span.reminder.time,
+  );
+
+  const current = resolveReminderAt(view, container);
+  if (current == null) {
+    return;
+  }
+
+  const modified = await modifyReminder(current.md, current.span.reminder, {
+    time: chosen,
+  });
+  if (!modified) {
+    return;
+  }
+
+  const rowNumber = current.span.reminder.rowNumber;
+  const newLine = current.md.toMarkdown().split("\n")[rowNumber] ?? "";
+  const line = view.state.doc.line(rowNumber + 1);
+  view.dispatch({
+    changes: { from: line.from, to: line.to, insert: newLine },
+    effects: [forceReminderPillRecompute.of()],
+  });
+}

--- a/src/plugin/ui/editor-reminder-display/spans.ts
+++ b/src/plugin/ui/editor-reminder-display/spans.ts
@@ -1,0 +1,50 @@
+import type { Text } from "@codemirror/state";
+import type { ReminderSpan } from "model/format";
+import type { ReminderPillSpan } from "./types";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Converts parser-provided `ReminderSpan`s (line-relative UTF-16 columns,
+ * addressed by `reminder.rowNumber`) into absolute `[from, to)` positions
+ * within the given CodeMirror document.
+ *
+ * Spans whose row no longer exists (stale parse against a shorter document)
+ * are dropped, positions are clamped to their line's bounds, and the result
+ * is sorted by `from` with overlapping ranges skipped (keeping the earlier
+ * one) so it's safe to feed straight into a `RangeSetBuilder`.
+ */
+export function deriveReminderPillSpans(
+  doc: Text,
+  reminderSpans: ReminderSpan[],
+): ReminderPillSpan[] {
+  const spans: ReminderPillSpan[] = [];
+  for (const { reminder, columnStart, columnEnd } of reminderSpans) {
+    const lineNumber = reminder.rowNumber + 1; // CM6 lines are 1-based.
+    if (lineNumber < 1 || lineNumber > doc.lines) {
+      continue;
+    }
+    const line = doc.line(lineNumber);
+    const from = clamp(line.from + columnStart, line.from, line.to);
+    const to = clamp(line.from + columnEnd, from, line.to);
+    if (from >= to) {
+      continue;
+    }
+    spans.push({ from, to, reminder, text: doc.sliceString(from, to) });
+  }
+
+  spans.sort((a, b) => a.from - b.from);
+
+  const nonOverlapping: ReminderPillSpan[] = [];
+  let lastTo = -1;
+  for (const span of spans) {
+    if (span.from < lastTo) {
+      continue;
+    }
+    nonOverlapping.push(span);
+    lastTo = span.to;
+  }
+  return nonOverlapping;
+}

--- a/src/plugin/ui/editor-reminder-display/state-effects.ts
+++ b/src/plugin/ui/editor-reminder-display/state-effects.ts
@@ -1,0 +1,13 @@
+import { StateEffect } from "@codemirror/state";
+
+/**
+ * Requests that the reminder pill `StateField` rebuild its decorations from
+ * a fresh parse of the document, even though the transaction carrying this
+ * effect may not itself touch a previously known reminder span.
+ *
+ * Dispatched by the debounced re-parse in `extension.ts` (paired with an
+ * annotation carrying the freshly computed spans) after edits that don't
+ * intersect any currently known reminder, and by the pill click handler in
+ * `pill-widget.ts` right after it rewrites a reminder's line.
+ */
+export const forceReminderPillRecompute = StateEffect.define<void>();

--- a/src/plugin/ui/editor-reminder-display/types.ts
+++ b/src/plugin/ui/editor-reminder-display/types.ts
@@ -1,0 +1,13 @@
+import type { Reminder } from "model/reminder";
+
+/**
+ * A reminder's time text located at an absolute `[from, to)` position within
+ * a CodeMirror 6 document, along with the reminder it belongs to and the
+ * text it covers (used as the pill's label).
+ */
+export interface ReminderPillSpan {
+  from: number;
+  to: number;
+  reminder: Reminder;
+  text: string;
+}

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -19,6 +19,7 @@ import { ReminderListItemViewProxy } from "./reminder-list";
 import { AutoComplete } from "./autocomplete";
 import type { AutoCompletableEditor } from "./autocomplete";
 import { buildCodeMirrorPlugin } from "./editor-extension";
+import { createReminderPillExtension } from "./editor-reminder-display";
 import { ReminderModal } from "./reminder";
 
 export class ReminderPluginUI {
@@ -82,6 +83,17 @@ export class ReminderPluginUI {
           this.plugin.settings,
         ),
       );
+      this.plugin.registerEditorExtension(
+        createReminderPillExtension(this.plugin),
+      );
+      // Reconfiguring editor extensions is how CM6 signals every open
+      // editor's `StateField` that something changed (`tr.reconfigured`),
+      // which is what lets the pill extension re-check the toggle
+      // immediately instead of only on the editor's next edit/selection
+      // change.
+      this.plugin.settings.editorReminderDisplay.rawValue.onChanged(() => {
+        this.plugin.app.workspace.updateOptions();
+      });
     }
 
     registerCommands(this.plugin);

--- a/src/ui/DateTimeChooser.svelte
+++ b/src/ui/DateTimeChooser.svelte
@@ -6,12 +6,20 @@
   import TimePicker from "./TimePicker.svelte";
   import ReminderListByDate from "./ReminderListByDate.svelte";
 
-  export let date = moment();
   export let reminders: Reminders;
   export let onSelect: (time: DateTime) => void;
   export let timeStep = 15;
-  let time = reminders.reminderTime?.value.toString() ?? "10:00";
-  let timeIsFocused = false;
+  // When set, pre-initializes the calendar (and, if it has a time part, the
+  // time input) from this value instead of the usual "now"/reminder-time
+  // defaults. Used when editing an existing reminder (e.g. from the editor
+  // pill) so the chooser opens on the reminder's current time.
+  export let initialTime: DateTime | undefined = undefined;
+
+  export let date = initialTime?.moment().clone() ?? moment();
+  let time = initialTime?.hasTimePart
+    ? initialTime.format("HH:mm")
+    : (reminders.reminderTime?.value.toString() ?? "10:00");
+  let timeIsFocused = initialTime?.hasTimePart ?? false;
 
   function handleSelect() {
     const [hour, minute] = time.split(":");


### PR DESCRIPTION
Supersedes #246 — reworked from scratch onto current master (the original branch had drifted 100+ commits behind and conflicted across the parser layer).

## What this does

In Live Preview, each reminder's time text (e.g. `(@2026-07-20 10:00)`, `📅 2026-07-20`) is rendered as a clickable pill (⏰ + time). Clicking the pill opens the date/time chooser pre-filled with the reminder's current time; choosing a new time rewrites only the reminder's own line. Moving the cursor into the pill reveals the raw text for direct editing; source mode always shows raw text.

## How

- **Parser layer**: `parseReminder()` now returns `ReminderSpan[]` (`reminder` + `columnStart`/`columnEnd`), with a new `computeSpan()` on each `ReminderModel` (default / Tasks / Kanban formats). Covered by unit tests including a recurrence-segment case.
- **Editor extension** (`src/plugin/ui/editor-reminder-display/`): a CM6 `StateField` holds decorations plus cached spans — mapped across unrelated edits, rebuilt immediately when an edit touches a known span, and re-parsed after a 300ms quiet period via a `ViewPlugin` that owns its debounce timer per view (cleared on `destroy()`).
- **Chooser**: `showDateTimeChooserModal()` accepts an optional `initialTime`; `DateTimeChooser.svelte` seeds its calendar (and, when present, time input) from it.
- **Setting**: new "Show reminder pills in editor" toggle (default on). Toggling calls `Workspace.updateOptions()`, and the field reacts to `tr.reconfigured`, so it applies to open editors immediately.

## Changes from the original #246 design

- No `globalThis` view registry / module-level debounce timer — the `ViewPlugin` owns its timer per editor view.
- The plugin instance is passed into the extension factory instead of `app.plugins.plugins[...]` lookups.
- Pill clicks re-resolve the target reminder from the widget's current DOM position at click time (and again after the modal closes), then rewrite only that line — instead of trusting positions captured at decoration-build time and replacing the whole document. This closes a window where an edit elsewhere within the debounce period could have rewritten the wrong line.
- Fixed an off-by-one in the Tasks-format span when the reminder symbol is the last token on the line (the original truncated the final character).
- Daily-note link rendering in the default format now applies to the time text only, so a date-like string in the title is never turned into a link.
- Remaining TODOs from #246 are done: disable setting, timer lifecycle cleanup, chooser initial-time threading, docs.

## Verification

- `npm run lint:fix` (eslint + tsc + svelte-check): 0 errors. `npm run test`: 13 suites / 138 tests passed. Production build succeeds.
- Manually verified in a test vault (desktop, Live Preview): pill rendering for default/Tasks formats incl. recurrence and end-of-line dates; cursor-in-span reveals raw text; source mode unaffected; pill click opens the chooser pre-filled with the current time and rewrites only the target line; cancel leaves the document untouched; the setting toggle applies to open editors immediately; reminder list view unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)