### PR TITLE
Parse Kanban time parts strictly to fix 12-hour time handling

### DIFF
--- a/src/model/format/reminder-kanban-plugin.test.ts
+++ b/src/model/format/reminder-kanban-plugin.test.ts
@@ -124,6 +124,60 @@ describe("KanbanDateTimeFormat", (): void => {
       expect(res.time!.toString()).toBe("2021-09-12");
     }
   });
+  test("split - span covers the matched text, not its canonical form", (): void => {
+    // Re-formatting a parsed 12-hour time yields a canonical 24-hour string
+    // of a different length (`@@{2:30 PM}` -> `@@{14:30}`), so the span must
+    // be taken from the text actually matched in the input.
+    const sut = new KanbanDateTimeFormat({
+      dateTrigger: "@",
+      dateFormat: "YYYY-MM-DD",
+      timeTrigger: "@@",
+      timeFormat: "HH:mm",
+      linkDateToDailyNote: false,
+    });
+
+    const expectSpanCovers = (
+      res: { span?: { start: number; end: number } },
+      input: string,
+      matchedText: string,
+    ): void => {
+      const start = input.indexOf(matchedText);
+      expect(start).toBeGreaterThanOrEqual(0);
+      expect(res.span).toEqual({ start, end: start + matchedText.length });
+    };
+
+    // 12-hour time (the #108 case).
+    {
+      const input = "a b c @{2021-09-12} @@{2:30 PM}";
+      expectSpanCovers(sut.split(input), input, "@{2021-09-12} @@{2:30 PM}");
+    }
+    // 24-hour time.
+    {
+      const input = "a b c @{2021-09-12} @@{14:30}";
+      expectSpanCovers(sut.split(input), input, "@{2021-09-12} @@{14:30}");
+    }
+    // date only.
+    {
+      const input = "a b c @{2021-09-12}";
+      expectSpanCovers(sut.split(input), input, "@{2021-09-12}");
+    }
+    // daily-note-link form.
+    {
+      const linked = new KanbanDateTimeFormat({
+        dateTrigger: "@",
+        dateFormat: "YYYY-MM-DD",
+        timeTrigger: "@@",
+        timeFormat: "HH:mm",
+        linkDateToDailyNote: true,
+      });
+      const input = "a b c @[[2021-09-12]] @@{2:30 PM}";
+      expectSpanCovers(
+        linked.split(input),
+        input,
+        "@[[2021-09-12]] @@{2:30 PM}",
+      );
+    }
+  });
   test("split - time part uses the configured format first when it is 12-hour", (): void => {
     const sut = new KanbanDateTimeFormat({
       dateTrigger: "@",
@@ -211,6 +265,16 @@ describe("KanbanReminderFormat", (): void => {
     const span = parsed!.computeSpan();
     expect(span.start).toBe(6);
     expect(span.end).toBe(29);
+  });
+  test("parse() with 12-hour time - computeSpan() covers the original text", (): void => {
+    // The matched text is 2 chars longer than its canonical form
+    // (`@@{2:30 PM}` vs `@@{14:30}`); the span must cover the original.
+    const line = "task1 @{2021-09-08} @@{2:30 PM}";
+    const parsed = KanbanReminderModel.parse(line);
+    expect(parsed!.time.toString()).toBe("2021-09-08 14:30");
+    const span = parsed!.computeSpan();
+    expect(line.slice(span.start, span.end)).toBe("@{2021-09-08} @@{2:30 PM}");
+    expect(span.end).toBe(line.length);
   });
   test("setDate() simple", (): void => {
     const parsed = KanbanReminderModel.parse("task1 @{2021-09-07}");

--- a/src/model/format/reminder-kanban-plugin.test.ts
+++ b/src/model/format/reminder-kanban-plugin.test.ts
@@ -70,6 +70,73 @@ describe("KanbanDateTimeFormat", (): void => {
       expect(res.time).toBe(undefined);
     }
   });
+  test("split - time part is always parsed strictly regardless of strictDateFormat (#108)", (): void => {
+    // The Kanban plugin's time picker can emit 12-hour times (`2:30 PM`)
+    // even when the configured/assumed time format is `HH:mm`. Non-strict
+    // parsing used to silently drop the " PM" suffix and register 2:30 AM
+    // instead — a silently wrong reminder time. The time part must now
+    // always be parsed strictly, trying known fallback formats, regardless
+    // of the strictDateFormat parameter passed in.
+    const sut = new KanbanDateTimeFormat({
+      dateTrigger: "@",
+      dateFormat: "YYYY-MM-DD",
+      timeTrigger: "@@",
+      timeFormat: "HH:mm",
+      linkDateToDailyNote: false,
+    });
+
+    // existing behavior preserved: configured HH:mm matches directly.
+    {
+      const res = sut.split("a b c @{2021-09-12} @@{14:30}");
+      expect(res.title).toBe("a b c");
+      expect(res.time!.toString()).toBe("2021-09-12 14:30");
+    }
+    // the #108 case: 12-hour time with a single-digit hour, parsed via the
+    // "h:mm A" fallback.
+    {
+      const res = sut.split("a b c @{2021-09-12} @@{2:30 PM}");
+      expect(res.title).toBe("a b c");
+      expect(res.time!.toString()).toBe("2021-09-12 14:30");
+    }
+    // 12-hour time with a zero-padded hour, parsed via the "hh:mm A"
+    // fallback.
+    {
+      const res = sut.split("a b c @{2021-09-12} @@{02:30 PM}");
+      expect(res.title).toBe("a b c");
+      expect(res.time!.toString()).toBe("2021-09-12 14:30");
+    }
+    // nonsense time text must not silently parse to a wrong time, even
+    // when strictDateFormat=false is explicitly passed.
+    {
+      const res = sut.split("a b c @{2021-09-12} @@{2:30 PM X}", false);
+      expect(res.title).toBe("a b c @{2021-09-12} @@{2:30 PM X}");
+      expect(res.time).toBe(undefined);
+    }
+    {
+      const res = sut.split("a b c @{2021-09-12} @@{25:99}", false);
+      expect(res.title).toBe("a b c @{2021-09-12} @@{25:99}");
+      expect(res.time).toBe(undefined);
+    }
+    // date-only input is unaffected and still honors strictDateFormat.
+    {
+      const res = sut.split("a b c @{2021-09-12}", false);
+      expect(res.title).toBe("a b c");
+      expect(res.time!.toString()).toBe("2021-09-12");
+    }
+  });
+  test("split - time part uses the configured format first when it is 12-hour", (): void => {
+    const sut = new KanbanDateTimeFormat({
+      dateTrigger: "@",
+      dateFormat: "YYYY-MM-DD",
+      timeTrigger: "@@",
+      timeFormat: "h:mm A",
+      linkDateToDailyNote: false,
+    });
+
+    const res = sut.split("a b c @{2021-09-12} @@{2:30 PM}");
+    expect(res.title).toBe("a b c");
+    expect(res.time!.toString()).toBe("2021-09-12 14:30");
+  });
   test("split - reflects setting changes after construction", (): void => {
     // The Kanban plugin's settings are read lazily, so toggling
     // "link date to daily note" must be reflected without recreating the

--- a/src/model/format/reminder-kanban-plugin.ts
+++ b/src/model/format/reminder-kanban-plugin.ts
@@ -61,6 +61,13 @@ const kanbanSetting = new (class KanbanSetting {
 type KanbanSplitResult = {
   title: string;
   time?: DateTime;
+  /**
+   * Range of the matched date/time text in the original input, present
+   * whenever `time` is present. The matched text (e.g. `@@{2:30 PM}`) can be
+   * longer than its canonical re-formatted form (e.g. `@@{14:30}`), so
+   * consumers must not derive this range from the canonical form.
+   */
+  span?: { start: number; end: number };
 };
 
 export class KanbanDateTimeFormat {
@@ -120,12 +127,29 @@ export class KanbanDateTimeFormat {
     } else {
       return { title: originalText };
     }
+    const dateStart = dateMatch.index;
+    const dateEnd = dateStart + dateMatch[0].length;
+    // Range of the matched date/time text in `originalText` coordinates.
+    let span = { start: dateStart, end: dateEnd };
 
     const timeRegExp = this.timeRegExp;
     const timeMatch = timeRegExp.exec(text);
     if (timeMatch) {
       time = timeMatch.groups!["time"]!;
       text = text.replace(timeRegExp, "");
+      // The time regex ran on the text with the date match removed, so map
+      // its index back to `originalText` coordinates: if it points at or
+      // after where the date started, the removed date segment was before
+      // it and its length must be added back.
+      const timeStart =
+        timeMatch.index >= dateStart
+          ? timeMatch.index + dateMatch[0].length
+          : timeMatch.index;
+      const timeEnd = timeStart + timeMatch[0].length;
+      span = {
+        start: Math.min(dateStart, timeStart),
+        end: Math.max(dateEnd, timeEnd),
+      };
     }
     const title = text.trim();
 
@@ -154,7 +178,7 @@ export class KanbanDateTimeFormat {
           true,
         );
         if (candidate.isValid()) {
-          return { title, time: new DateTime(candidate, true) };
+          return { title, time: new DateTime(candidate, true), span };
         }
       }
       return { title: originalText };
@@ -166,7 +190,7 @@ export class KanbanDateTimeFormat {
       false,
     );
     if (parsedTime.isValid()) {
-      return { title, time: parsedTime };
+      return { title, time: parsedTime, span };
     }
     return { title: originalText };
   }
@@ -184,12 +208,19 @@ export class KanbanReminderModel implements ReminderModel {
     if (splitted.time == null) {
       return null;
     }
-    return new KanbanReminderModel(splitted.title, splitted.time);
+    return new KanbanReminderModel(
+      splitted.title,
+      splitted.time,
+      splitted.span,
+    );
   }
 
   constructor(
     public title: string,
     public time: DateTime,
+    // Range of the matched date/time text in the parsed source line. Absent
+    // for models built by newReminder(), which have no source text.
+    private span?: { start: number; end: number },
   ) {}
 
   getTitle(): string {
@@ -205,6 +236,10 @@ export class KanbanReminderModel implements ReminderModel {
 
   setTime(time: DateTime): void {
     this.time = time;
+    // The stored span describes the original source line; after the time is
+    // replaced, the line becomes the canonical toMarkdown() output, so fall
+    // back to the canonical-length computation in computeSpan().
+    this.span = undefined;
   }
 
   setRawTime(): boolean {
@@ -216,6 +251,15 @@ export class KanbanReminderModel implements ReminderModel {
   }
 
   computeSpan(): { start: number; end: number } {
+    // Prefer the range actually matched in the source line: re-formatting
+    // the parsed time can change its length (e.g. `@@{2:30 PM}` parses to a
+    // canonical `@@{14:30}`, 2 chars shorter), so a span derived from the
+    // canonical form would drift from the document text.
+    if (this.span) {
+      return this.span;
+    }
+    // Fallback for models without source text (newReminder(), or after
+    // setTime() replaced the time): the document text is the canonical
     // toMarkdown() = `${title.trim()} ${formatted time}`, so the time text
     // starts right after "title.trim() " (one separating space) and runs to
     // the end of the markdown.

--- a/src/model/format/reminder-kanban-plugin.ts
+++ b/src/model/format/reminder-kanban-plugin.ts
@@ -129,23 +129,42 @@ export class KanbanDateTimeFormat {
     }
     const title = text.trim();
 
-    let parsedTime: DateTime;
-    const strict = strictDateFormat ?? true;
     if (time) {
-      parsedTime = new DateTime(
-        moment(
-          `${date} ${time}`,
-          `${this.setting.dateFormat} ${this.setting.timeFormat}`,
-          strict,
+      // Kanban's time picker can emit either 24-hour times (`HH:mm`) or
+      // 12-hour times (`h:mm A`/`hh:mm A`), and the format we assume here is
+      // read live from the Kanban plugin's settings, which may be stale,
+      // unreadable, or simply not match what the user actually typed.
+      // Non-strict moment parsing silently discards trailing text it can't
+      // match (e.g. it drops " PM" and quietly parses "2:30 PM" as 02:30
+      // AM), turning a format mismatch into a *wrong* reminder time instead
+      // of a missing one. So this path always parses strictly — ignoring
+      // the global strictDateFormat setting, which still governs the
+      // date-only path below — and tries a short list of candidate time
+      // formats, accepting the first one that parses strictly.
+      const candidateTimeFormats = [
+        this.setting.timeFormat,
+        ...["h:mm A", "hh:mm A", "HH:mm"].filter(
+          (format) => format !== this.setting.timeFormat,
         ),
-        true,
-      );
-    } else {
-      parsedTime = new DateTime(
-        moment(date, this.setting.dateFormat, strict),
-        false,
-      );
+      ];
+      for (const timeFormat of candidateTimeFormats) {
+        const candidate = moment(
+          `${date} ${time}`,
+          `${this.setting.dateFormat} ${timeFormat}`,
+          true,
+        );
+        if (candidate.isValid()) {
+          return { title, time: new DateTime(candidate, true) };
+        }
+      }
+      return { title: originalText };
     }
+
+    const strict = strictDateFormat ?? true;
+    const parsedTime = new DateTime(
+      moment(date, this.setting.dateFormat, strict),
+      false,
+    );
     if (parsedTime.isValid()) {
       return { title, time: parsedTime };
     }


### PR DESCRIPTION
## Summary

Fixes #108: Kanban cards with 12-hour times like `@@{2:30 PM}` were silently registered as 2:30 **AM**.

The Kanban format parser reads the time format live from the Kanban plugin's settings (falling back to `HH:mm`) and parsed with moment in non-strict mode. When the assumed format and the actual text disagree, non-strict moment silently discards the unmatched ` PM` suffix, turning a format mismatch into a *wrong* reminder time instead of a missing one.

## Fix

`KanbanDateTimeFormat.split()`'s date+time path now:

- always parses **strictly**, ignoring the global `strictDateFormat` setting (which still governs the date-only path), and
- tries candidate time formats in order: the configured Kanban format first, then `h:mm A`, `hh:mm A`, `HH:mm`. The first strict-valid candidate wins.

This both fixes the reported case (`2:30 PM` with an assumed `HH:mm` now parses correctly via the fallback) and removes the silent-wrong-time failure mode: if nothing parses strictly, no reminder is registered (fail closed).

## Testing

- New unit tests in `reminder-kanban-plugin.test.ts` covering: 24-hour input (regression), `2:30 PM` / `02:30 PM` via fallbacks, configured 12-hour format, garbage time input rejected even with `strictDateFormat=false`, and the date-only path unchanged.
- `mise run main:lint:fix` clean; `mise run main:test` 13 suites / 142 tests passing; production build succeeds.
- Manual verification in a test vault to follow; results will be posted as a comment.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)