### PR TITLE
Add toast-style reminder popups and an overdue count status bar badge

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -49,6 +49,8 @@ By default the popup is shown as a small card stacked in the bottom-right corner
 
 Multiple toasts stack when several reminders fire close together. The [keyboard shortcuts](#keyboard-shortcuts) above only apply to the most recently shown toast (the bottom-most card in the stack); older toasts fall back to the buttons on the card (mouse/touch only), since two toasts both reacting to the same keypress would be confusing.
 
+Because toasts don't take focus, they appear immediately even while you're typing — the [Edit Detection Time](/setting/#edit-detection-time) deferral only applies to the modal style.
+
 ## System notification
 
 Instead of built-in notification, a system notification is also available by [setting](/setting/#use-system-notification).

--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -45,7 +45,9 @@ If another app on your system already captures the Option/Alt combination (windo
 
 ### Toast style
 
-By default the popup is a modal dialog centered in the window and takes focus. Set [Reminder popup style](/setting/#reminder-popup-style) to `Toast (corner card)` to show it instead as a small card stacked in the bottom-right corner, which does not take focus or interrupt what you're doing. Multiple toasts stack when several reminders fire close together, and keyboard shortcuts are not available in this mode (use the buttons on the card instead).
+By default the popup is shown as a small card stacked in the bottom-right corner, which does not take focus or interrupt what you're doing. Set [Reminder popup style](/setting/#reminder-popup-style) to `Modal (center dialog)` to show it instead as a modal dialog centered in the window that takes focus.
+
+Multiple toasts stack when several reminders fire close together. The [keyboard shortcuts](#keyboard-shortcuts) above only apply to the most recently shown toast (the bottom-most card in the stack); older toasts fall back to the buttons on the card (mouse/touch only), since two toasts both reacting to the same keypress would be confusing.
 
 ## System notification
 

--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -43,6 +43,10 @@ Instead, the popup supports Alt (Option on macOS) or Ctrl mnemonic shortcuts, wh
 
 If another app on your system already captures the Option/Alt combination (window managers, launchers), use the Ctrl variant instead.
 
+### Toast style
+
+By default the popup is a modal dialog centered in the window and takes focus. Set [Reminder popup style](/setting/#reminder-popup-style) to `Toast (corner card)` to show it instead as a small card stacked in the bottom-right corner, which does not take focus or interrupt what you're doing. Multiple toasts stack when several reminders fire close together, and keyboard shortcuts are not available in this mode (use the buttons on the card instead).
+
 ## System notification
 
 Instead of built-in notification, a system notification is also available by [setting](/setting/#use-system-notification).
@@ -95,3 +99,7 @@ While paused:
 - Reminders are not muted by the pause, so any reminder that's still overdue is notified again shortly after the pause ends.
 
 A status bar item (🔕) shows the time the pause ends; click it to resume notifications immediately. You can also run `Resume reminder notifications` from the command palette, which is only available while paused. The pause is remembered across Obsidian restarts, but it's a transient state rather than a setting, so it doesn't appear in the settings tab.
+
+## Overdue count in the status bar
+
+A status bar item (e.g. `⏰ 3`) shows how many reminders are currently overdue, including muted ones. It's hidden whenever there are none. Click it to open the [reminder list view](/guide/list-reminders.html). Controlled by [Show overdue count in status bar](/setting/#show-overdue-count-in-status-bar), which is on by default.

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -141,8 +141,8 @@ Choose how the [builtin notification popup](/guide/notification.html#builtin-not
 
 - Type: `select`
 - Values:
-  - Modal (center dialog): a dialog in the center of the window that takes focus.
   - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing (default). Multiple toasts stack when several reminders fire close together. Keyboard shortcuts apply only to the most recently shown toast; older toasts are mouse/touch only. Toasts appear immediately, even while you're typing — see [Edit Detection Time](#edit-detection-time).
+  - Modal (center dialog): a dialog in the center of the window that takes focus.
 - Default: Toast (corner card)
 
 ## Open note on reminder click

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -142,7 +142,7 @@ Choose how the [builtin notification popup](/guide/notification.html#builtin-not
 - Type: `select`
 - Values:
   - Modal (center dialog): a dialog in the center of the window that takes focus.
-  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing (default). Multiple toasts stack when several reminders fire close together. Keyboard shortcuts apply only to the most recently shown toast; older toasts are mouse/touch only.
+  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing (default). Multiple toasts stack when several reminders fire close together. Keyboard shortcuts apply only to the most recently shown toast; older toasts are mouse/touch only. Toasts appear immediately, even while you're typing — see [Edit Detection Time](#edit-detection-time).
 - Default: Toast (corner card)
 
 ## Open note on reminder click
@@ -229,6 +229,8 @@ Enable support for [Kanban Plugin](https://github.com/mgmeyers/obsidian-kanban)
 
 In order not to interfere with normal Markdown editing, the Reminder Plugin will not show reminders while the user is editing a file.
 The value of this setting is the minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable.
+
+This only applies to the [Modal popup style](#reminder-popup-style), which takes focus and would otherwise interrupt typing. The Toast popup style is not focus-stealing, so toasts appear immediately regardless of this setting.
 
 - Type: `number`
 - Value: The value of this setting is the minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable. If this value is set to 0, the reminder will be displayed even if the file is being edited.

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -135,6 +135,16 @@ Show reminder popups and system notifications when a reminder is due.
   - OFF: Reminder popups/system notifications are suppressed. The [reminder list view](/guide/list-reminders.html) keeps updating, and expired reminders still move to the [Overdue section](/guide/list-reminders.html#overdue-reminders).
 - Default: ON
 
+## Reminder popup style
+
+Choose how the [builtin notification popup](/guide/notification.html#builtin-notification-modal) is presented.
+
+- Type: `select`
+- Values:
+  - Modal (center dialog): a dialog in the center of the window that takes focus (default)
+  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing. Multiple toasts stack when several reminders fire close together.
+- Default: Modal (center dialog)
+
 ## Open note on reminder click
 
 Open the note directly instead of showing the reminder popup when you click a reminder.
@@ -295,3 +305,13 @@ You can quickly apply a preset via the command palette:
 Running the command opens a chooser with live examples. Selecting a preset immediately saves settings and refreshes the Reminder List.
 
 - Default: `5`
+
+## Show overdue count in status bar
+
+Show the number of overdue reminders in the status bar (e.g. `⏰ 3`). Muted overdue reminders are still counted. Click the status bar item to open the [reminder list view](/guide/list-reminders.html).
+
+- Type: `boolean`
+- Values:
+  - ON: The status bar item is shown whenever there is at least one overdue reminder (default)
+  - OFF: The status bar item is never shown
+- Default: ON

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -141,9 +141,9 @@ Choose how the [builtin notification popup](/guide/notification.html#builtin-not
 
 - Type: `select`
 - Values:
-  - Modal (center dialog): a dialog in the center of the window that takes focus (default)
-  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing. Multiple toasts stack when several reminders fire close together.
-- Default: Modal (center dialog)
+  - Modal (center dialog): a dialog in the center of the window that takes focus.
+  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing (default). Multiple toasts stack when several reminders fire close together. Keyboard shortcuts apply only to the most recently shown toast; older toasts are mouse/touch only.
+- Default: Toast (corner card)
 
 ## Open note on reminder click
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,11 @@ export default class ReminderPlugin extends Plugin {
       isLayoutReady: () => this.app.workspace.layoutReady,
       reloadUI: (force) => this.ui.reload(force),
       isEditing: () => this.ui.isEditing(),
+      // Deliberately `!== "toast"` rather than `=== "modal"`: any future/
+      // unknown popup style value falls back to the previous, conservative
+      // (intrusive) behavior.
+      isPopupIntrusive: () =>
+        this.settings.notificationPopupStyle.value !== "toast",
       showReminder: (reminder) => this.ui.showReminder(reminder),
       isScanned: () => this.data.scanned.value,
       markScanned: () => {

--- a/src/plugin/notification-worker.test.ts
+++ b/src/plugin/notification-worker.test.ts
@@ -15,6 +15,7 @@ function createDeps(
     isLayoutReady: () => true,
     reloadUI: () => {},
     isEditing: () => false,
+    isPopupIntrusive: () => true,
     showReminder: () => {},
     isScanned: () => true,
     markScanned: () => {},
@@ -74,11 +75,12 @@ describe("NotificationWorker", (): void => {
     expect(shown).toStrictEqual([r2]);
   });
 
-  test("shows nothing while isEditing() is true", async (): Promise<void> => {
+  test("shows nothing while isEditing() is true and the popup is intrusive (modal)", async (): Promise<void> => {
     const showReminder = jest.fn();
     const getExpiredReminders = jest.fn(() => [makeReminder("r1")]);
     const deps = createDeps({
       isEditing: () => true,
+      isPopupIntrusive: () => true,
       getExpiredReminders,
       showReminder,
     });
@@ -88,6 +90,38 @@ describe("NotificationWorker", (): void => {
 
     expect(getExpiredReminders).not.toHaveBeenCalled();
     expect(showReminder).not.toHaveBeenCalled();
+  });
+
+  test("shows reminders while isEditing() is true when the popup is not intrusive (toast)", async (): Promise<void> => {
+    const showReminder = jest.fn();
+    const reminder = makeReminder("r1");
+    const deps = createDeps({
+      isEditing: () => true,
+      isPopupIntrusive: () => false,
+      getExpiredReminders: () => [reminder],
+      showReminder,
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(showReminder).toHaveBeenCalledWith(reminder);
+  });
+
+  test("shows reminders when not editing, regardless of popup intrusiveness", async (): Promise<void> => {
+    const showReminder = jest.fn();
+    const reminder = makeReminder("r1");
+    const deps = createDeps({
+      isEditing: () => false,
+      isPopupIntrusive: () => true,
+      getExpiredReminders: () => [reminder],
+      showReminder,
+    });
+    const worker = new NotificationWorker(deps);
+
+    await callPeriodicTask(worker);
+
+    expect(showReminder).toHaveBeenCalledWith(reminder);
   });
 
   test("does not show reminders when notifications are disabled", async (): Promise<void> => {

--- a/src/plugin/notification-worker.ts
+++ b/src/plugin/notification-worker.ts
@@ -11,6 +11,12 @@ export interface NotificationWorkerDeps {
   isLayoutReady(): boolean;
   reloadUI(force: boolean): void;
   isEditing(): boolean;
+  /**
+   * True when showing a reminder would open a focus-stealing UI (the modal
+   * popup style). Used to decide whether edit detection should defer the
+   * popup.
+   */
+  isPopupIntrusive(): boolean;
   showReminder(reminder: Reminder): void;
   isScanned(): boolean;
   markScanned(): void;
@@ -67,7 +73,9 @@ export class NotificationWorker {
 
     this.deps.saveData(false);
 
-    if (this.deps.isEditing()) {
+    // Edit detection only defers focus-stealing popups (the modal style);
+    // non-intrusive styles (toast) show immediately even while typing.
+    if (this.deps.isPopupIntrusive() && this.deps.isEditing()) {
       return;
     }
 

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -31,6 +31,7 @@ export class Settings {
   reminderTime: SettingModel<string, Time>;
   reminderTimeStep: SettingModel<number, number>;
   enableNotification: SettingModel<boolean, boolean>;
+  notificationPopupStyle: SettingModel<string, string>;
   openNoteOnReminderClick: SettingModel<boolean, boolean>;
   useSystemNotification: SettingModel<boolean, boolean>;
   showPopupWithSystemNotification: SettingModel<boolean, boolean>;
@@ -54,6 +55,7 @@ export class Settings {
   shortDateWithWeekdayDisplayFormat: SettingModel<string, string>;
   editDetectionSec: SettingModel<number, number>;
   reminderCheckIntervalSec: SettingModel<number, number>;
+  showOverdueCountInStatusBar: SettingModel<boolean, boolean>;
 
   constructor() {
     const reminderFormatSettings = new ReminderFormatSettings(this.settings);
@@ -84,6 +86,18 @@ export class Settings {
         "If disabled, reminder popups and system notifications are not shown. The reminder list view keeps working.",
       )
       .toggle(true)
+      .build(new RawSerde());
+
+    this.notificationPopupStyle = this.settings
+      .newSettingBuilder()
+      .key("notificationPopupStyle")
+      .name("Reminder popup style")
+      .desc(
+        "Modal: a dialog in the center of the window that takes focus. Toast: a card in the corner of the window that does not interrupt your work.",
+      )
+      .dropdown("modal")
+      .addOption("Modal (center dialog)", "modal")
+      .addOption("Toast (corner card)", "toast")
       .build(new RawSerde());
 
     this.openNoteOnReminderClick = this.settings
@@ -361,6 +375,16 @@ export class Settings {
       .number(5)
       .build(new RawSerde());
 
+    this.showOverdueCountInStatusBar = this.settings
+      .newSettingBuilder()
+      .key("showOverdueCountInStatusBar")
+      .name("Show overdue count in status bar")
+      .desc(
+        "Show the number of overdue reminders in the status bar. Click it to open the reminder list.",
+      )
+      .toggle(true)
+      .build(new RawSerde());
+
     this.settings
       .newGroup("Notification Settings")
       .addSettings(
@@ -368,10 +392,12 @@ export class Settings {
         this.reminderTimeStep,
         this.laters,
         this.enableNotification,
+        this.notificationPopupStyle,
         this.openNoteOnReminderClick,
         this.useSystemNotification,
         this.showPopupWithSystemNotification,
         this.focusDoneButtonOnPopup,
+        this.showOverdueCountInStatusBar,
       );
     this.settings
       .newGroup("Editor")

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -93,11 +93,11 @@ export class Settings {
       .key("notificationPopupStyle")
       .name("Reminder popup style")
       .desc(
-        "Modal: a dialog in the center of the window that takes focus. Toast: a card in the corner of the window that does not interrupt your work.",
+        "Toast: a card in the corner of the window that does not interrupt your work. Modal: a dialog in the center of the window that takes focus.",
       )
       .dropdown("toast")
-      .addOption("Modal (center dialog)", "modal")
       .addOption("Toast (corner card)", "toast")
+      .addOption("Modal (center dialog)", "modal")
       .build(new RawSerde());
 
     this.openNoteOnReminderClick = this.settings

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -95,7 +95,7 @@ export class Settings {
       .desc(
         "Modal: a dialog in the center of the window that takes focus. Toast: a card in the corner of the window that does not interrupt your work.",
       )
-      .dropdown("modal")
+      .dropdown("toast")
       .addOption("Modal (center dialog)", "modal")
       .addOption("Toast (corner card)", "toast")
       .build(new RawSerde());

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -361,7 +361,7 @@ export class Settings {
       .key("editDetectionSec")
       .name("Edit Detection Time")
       .desc(
-        "The minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable.",
+        "The minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable. Only applies to the Modal popup style; Toast reminders are shown immediately even while typing.",
       )
       .number(10)
       .build(new RawSerde());

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -17,6 +17,7 @@ import { showPauseDurationChooser } from "plugin/dnd";
 import { monkeyPatchConsole } from "plugin/obsidian-hack/obsidian-debug-mobile";
 import { VIEW_TYPE_REMINDER_LIST } from "./constants";
 import { DndStatusBar } from "./dnd-status-bar";
+import { OverdueStatusBar } from "./overdue-status-bar";
 import { ReminderListItemViewProxy } from "./reminder-list";
 import { AutoComplete } from "./autocomplete";
 import type { AutoCompletableEditor } from "./autocomplete";
@@ -34,6 +35,7 @@ export class ReminderPluginUI {
   private reminderModal: ReminderModal;
   private viewProxy: ReminderListItemViewProxy;
   private dndStatusBar: DndStatusBar;
+  private overdueStatusBar: OverdueStatusBar;
   constructor(private plugin: ReminderPlugin) {
     this.viewProxy = new ReminderListItemViewProxy(
       this.plugin,
@@ -64,12 +66,15 @@ export class ReminderPluginUI {
       plugin.settings.openNoteOnReminderClick,
       plugin.settings.showPopupWithSystemNotification,
       plugin.settings.focusDoneButtonOnPopup,
+      plugin.settings.notificationPopupStyle,
     );
     this.dndStatusBar = new DndStatusBar(plugin);
+    this.overdueStatusBar = new OverdueStatusBar(plugin);
   }
 
   onload() {
     this.dndStatusBar.onload();
+    this.overdueStatusBar.onload();
 
     // Reminder List
     this.plugin.registerView(VIEW_TYPE_REMINDER_LIST, (leaf: WorkspaceLeaf) => {
@@ -121,6 +126,7 @@ export class ReminderPluginUI {
 
   onunload() {
     this.detachReminderList();
+    this.reminderModal.destroy();
   }
 
   isEditing(): boolean {
@@ -129,10 +135,12 @@ export class ReminderPluginUI {
 
   invalidate() {
     this.viewProxy.invalidate();
+    this.overdueStatusBar.refresh();
   }
 
   reload(force: boolean = false) {
     this.viewProxy.reload(force);
+    this.overdueStatusBar.refresh();
   }
 
   showAutoComplete(editor: AutoCompletableEditor) {

--- a/src/plugin/ui/overdue-status-bar.ts
+++ b/src/plugin/ui/overdue-status-bar.ts
@@ -1,0 +1,60 @@
+import type ReminderPlugin from "main";
+
+const REFRESH_INTERVAL_MILLIS = 10 * 1000;
+
+/**
+ * Status bar item that shows the number of overdue reminders (e.g. "⏰ 3"),
+ * including muted ones -- they are still overdue, just silenced. Hidden when
+ * there are none, or when the [[Settings.showOverdueCountInStatusBar]]
+ * setting is off. Clicking it opens the reminder list view.
+ */
+export class OverdueStatusBar {
+  // Created lazily in `onload()` rather than the constructor, since
+  // `addStatusBarItem()` is an Obsidian API call and this class (like
+  // `DndStatusBar`) is constructed before the plugin has loaded.
+  private el?: HTMLElement;
+
+  constructor(private plugin: ReminderPlugin) {}
+
+  onload() {
+    this.el = this.plugin.addStatusBarItem();
+    this.el.addClass("reminder-overdue-status-bar");
+    this.el.style.display = "none";
+    this.el.style.cursor = "pointer";
+    this.el.setAttribute(
+      "aria-label",
+      "Overdue reminders — click to open the reminder list",
+    );
+    this.plugin.registerDomEvent(this.el, "click", () => {
+      void this.plugin.ui.showReminderList();
+    });
+
+    this.plugin.settings.showOverdueCountInStatusBar.rawValue.onChanged(() =>
+      this.refresh(),
+    );
+
+    this.plugin.registerInterval(
+      window.setInterval(() => this.refresh(), REFRESH_INTERVAL_MILLIS),
+    );
+    this.refresh();
+  }
+
+  refresh() {
+    if (!this.el) {
+      return;
+    }
+    if (!this.plugin.settings.showOverdueCountInStatusBar.value) {
+      this.el.style.display = "none";
+      return;
+    }
+    const count = this.plugin.reminders.getExpiredReminders(
+      this.plugin.settings.reminderTime.value,
+    ).length;
+    if (count === 0) {
+      this.el.style.display = "none";
+      return;
+    }
+    this.el.setText(`⏰ ${count}`);
+    this.el.style.display = "";
+  }
+}

--- a/src/plugin/ui/reminder-toast.ts
+++ b/src/plugin/ui/reminder-toast.ts
@@ -39,6 +39,10 @@ export class ReminderToastManager {
         reminder,
         laters,
         variant: "toast",
+        // Set to the right value up front (rather than relying only on the
+        // post-insert `updateShortcutTarget()` call below) to avoid a brief
+        // flicker where two toasts both have shortcuts enabled.
+        shortcutsEnabled: true,
         onRemindMeLater: (time: DateTime) => {
           onRemindMeLater(time);
           this.remove(key);
@@ -75,6 +79,7 @@ export class ReminderToastManager {
     });
 
     this.toasts.set(key, { el: cardEl, component });
+    this.updateShortcutTarget();
   }
 
   /** Unmounts and removes every toast and the container (for plugin unload). */
@@ -93,6 +98,22 @@ export class ReminderToastManager {
     entry.component.$destroy();
     entry.el.remove();
     this.toasts.delete(key);
+    this.updateShortcutTarget();
+  }
+
+  /**
+   * Keeps keyboard mnemonics active on exactly one toast: the most recently
+   * shown one. Each toast mounts its own `svelte:window` keydown handler
+   * (see `Reminder.svelte`), so if more than one had shortcuts enabled, a
+   * single keypress would trigger all of them at once. `this.toasts`
+   * preserves insertion order, so the last entry is the newest toast.
+   */
+  private updateShortcutTarget() {
+    const keys = Array.from(this.toasts.keys());
+    const lastKey = keys[keys.length - 1];
+    this.toasts.forEach(({ component }, key) => {
+      component.$set({ shortcutsEnabled: key === lastKey });
+    });
   }
 
   private getContainer(): HTMLElement {

--- a/src/plugin/ui/reminder-toast.ts
+++ b/src/plugin/ui/reminder-toast.ts
@@ -1,0 +1,109 @@
+import type { Reminder } from "model/reminder";
+import type { DateTime, Later } from "model/time";
+import ReminderView from "ui/Reminder.svelte";
+
+/**
+ * Manages non-modal "toast" reminder popups stacked in the bottom-right
+ * corner of the window. Unlike `NotificationModal` (see reminder.ts), toasts
+ * never take focus and multiple toasts can be shown at once, so they don't
+ * participate in `reminder.beingDisplayed` serialization: the notification
+ * worker fires them all without waiting.
+ */
+export class ReminderToastManager {
+  // Created lazily on the first `show()` call rather than in the
+  // constructor, mirroring `DndStatusBar`/`ReminderModal` -- this class is
+  // constructed before the plugin (and `document.body`) is guaranteed ready.
+  private containerEl?: HTMLElement;
+  private toasts: Map<string, { el: HTMLElement; component: ReminderView }> =
+    new Map();
+
+  show(
+    reminder: Reminder,
+    laters: Array<Later>,
+    onRemindMeLater: (time: DateTime) => void,
+    onDone: () => void,
+    onCancel: () => void,
+    onOpenFile: () => void,
+    onPauseAllNotifications: () => void,
+    onMuteAll: () => void,
+  ) {
+    const key = reminder.key();
+    // Replace rather than stack a second toast for the same reminder (e.g.
+    // it expires again before the first toast was dismissed).
+    this.remove(key);
+
+    const cardEl = this.getContainer().createDiv("reminder-toast-card");
+    const component = new ReminderView({
+      target: cardEl,
+      props: {
+        reminder,
+        laters,
+        variant: "toast",
+        onRemindMeLater: (time: DateTime) => {
+          onRemindMeLater(time);
+          this.remove(key);
+        },
+        onDone: () => {
+          onDone();
+          this.remove(key);
+        },
+        onOpenFile: () => {
+          // Matches NotificationModal: opening the file also mutes the
+          // reminder (closing the modal with `canceled = true` triggers
+          // `onCancel` there).
+          onOpenFile();
+          onCancel();
+          this.remove(key);
+        },
+        onMute: () => {
+          onCancel();
+          this.remove(key);
+        },
+        onClose: () => {
+          onCancel();
+          this.remove(key);
+        },
+        onPauseAllNotifications: () => {
+          onPauseAllNotifications();
+          this.remove(key);
+        },
+        onMuteAll: () => {
+          onMuteAll();
+          this.remove(key);
+        },
+      },
+    });
+
+    this.toasts.set(key, { el: cardEl, component });
+  }
+
+  /** Unmounts and removes every toast and the container (for plugin unload). */
+  destroy() {
+    this.toasts.forEach(({ component }) => component.$destroy());
+    this.toasts.clear();
+    this.containerEl?.remove();
+    this.containerEl = undefined;
+  }
+
+  private remove(key: string) {
+    const entry = this.toasts.get(key);
+    if (!entry) {
+      return;
+    }
+    entry.component.$destroy();
+    entry.el.remove();
+    this.toasts.delete(key);
+  }
+
+  private getContainer(): HTMLElement {
+    if (!this.containerEl) {
+      const el = document.body.createDiv("reminder-toast-container");
+      el.style.cssText =
+        "position: fixed; right: 16px; bottom: 40px; z-index: var(--layer-notice); " +
+        "display: flex; flex-direction: column; gap: 8px; max-height: 70vh; " +
+        "overflow-y: auto; width: 360px; max-width: calc(100vw - 32px);";
+      this.containerEl = el;
+    }
+    return this.containerEl;
+  }
+}

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -3,9 +3,12 @@ import type { Reminder } from "model/reminder";
 import type { DateTime, Later } from "model/time";
 import { App, Modal } from "obsidian";
 import ReminderView from "ui/Reminder.svelte";
+import { ReminderToastManager } from "./reminder-toast";
 const electron = window.require ? window.require("electron") : undefined;
 
 export class ReminderModal {
+  private toastManager: ReminderToastManager = new ReminderToastManager();
+
   constructor(
     private app: App,
     private useSystemNotification: ReadOnlyReference<boolean>,
@@ -13,7 +16,13 @@ export class ReminderModal {
     private openNoteOnReminderClick: ReadOnlyReference<boolean>,
     private showPopupWithSystemNotification: ReadOnlyReference<boolean>,
     private focusDoneButtonOnPopup: ReadOnlyReference<boolean>,
+    private notificationPopupStyle: ReadOnlyReference<string>,
   ) {}
+
+  /** Unmounts every open toast (for plugin unload). */
+  destroy() {
+    this.toastManager.destroy();
+  }
 
   public show(
     reminder: Reminder,
@@ -133,6 +142,19 @@ export class ReminderModal {
     onPauseAllNotifications: () => void,
     onMuteAll: () => void,
   ) {
+    if (this.notificationPopupStyle.value === "toast") {
+      this.toastManager.show(
+        reminder,
+        this.laters.value,
+        onRemindMeLater,
+        onDone,
+        onCancel,
+        onOpenFile,
+        onPauseAllNotifications,
+        onMuteAll,
+      );
+      return;
+    }
     new NotificationModal(
       this.app,
       this.laters.value,

--- a/src/ui/Reminder.svelte
+++ b/src/ui/Reminder.svelte
@@ -12,6 +12,12 @@
   export let onMute: () => void;
   export let onPauseAllNotifications: () => void;
   export let onMuteAll: () => void;
+  // "modal": Obsidian's centered dialog (default, unchanged behavior).
+  // "toast": a non-focus-stealing corner card; see the toast-specific
+  // branches below (onMount, svelte:window, close button, styling).
+  export let variant: "modal" | "toast" = "modal";
+  // Only used by the toast variant's close (x) button.
+  export let onClose: (() => void) | undefined = undefined;
   // Whether the Done button should be auto-focused when the popup opens.
   // Off by default so a stray Enter/Space keypress right after the popup
   // appears doesn't accidentally complete a reminder the user hasn't read.
@@ -38,6 +44,12 @@
   // managers, launchers) intercept Option/Alt chords before they reach
   // Obsidian -- common on macOS, where Ctrl+letter is nearly always free.
   function handleKeydown(evt: KeyboardEvent) {
+    if (variant === "toast") {
+      // Multiple toasts can be shown at once; if each registered these
+      // shortcuts, one keypress would trigger all of them. Toasts are
+      // operated with the mouse/touch only.
+      return;
+    }
     const alt = evt.altKey && !evt.ctrlKey;
     const ctrl = evt.ctrlKey && !evt.altKey;
     if ((!alt && !ctrl) || evt.metaKey || evt.shiftKey) {
@@ -68,6 +80,11 @@
   }
 
   onMount(async () => {
+    if (variant === "toast") {
+      // Toasts are non-intrusive corner cards: never steal focus from
+      // whatever the user is doing, unlike the modal below.
+      return;
+    }
     await tick();
     if (focusDone) {
       doneButton.focus();
@@ -82,10 +99,17 @@
 </script>
 
 <!-- Capture phase so the shortcuts run before Obsidian's own keymap/hotkey
-handlers (e.g. Ctrl+O would otherwise also trigger the quick switcher). -->
+handlers (e.g. Ctrl+O would otherwise also trigger the quick switcher).
+`<svelte:window>` can't be placed inside an `{#if}` block, so the toast
+variant is excluded inside `handleKeydown` itself instead. -->
 <svelte:window on:keydown|capture={handleKeydown} />
 
-<main bind:this={containerEl} tabindex="-1">
+<main bind:this={containerEl} tabindex="-1" class:toast={variant === "toast"}>
+  {#if variant === "toast"}
+    <button class="reminder-toast-close" on:click={onClose} aria-label="Close">
+      ×
+    </button>
+  {/if}
   <h3 class="reminder-title" aria-label={reminder.title}>
     <Markdown markdown={reminder.title} sourcePath={reminder.file} />
   </h3>
@@ -211,5 +235,52 @@ handlers (e.g. Ctrl+O would otherwise also trigger the quick switcher). -->
 
   .mnemonic {
     text-decoration: underline;
+  }
+
+  main.toast {
+    position: relative;
+    background: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m, 8px);
+    box-shadow: var(--shadow-s);
+    padding: 12px 14px;
+  }
+
+  main.toast .reminder-title {
+    margin: 0 1.5rem 0.3rem 0;
+    font-size: 0.95rem;
+  }
+
+  main.toast .reminder-actions {
+    margin-top: 0.5rem;
+  }
+
+  main.toast .reminder-secondary-actions {
+    gap: 0.75rem;
+  }
+
+  main.toast .reminder-footer-action {
+    margin-top: 0.5rem;
+  }
+
+  .reminder-toast-close {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    padding: 0;
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+    text-align: center;
+    color: var(--text-muted);
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+    cursor: pointer;
+    font-size: 16px;
+  }
+
+  .reminder-toast-close:hover {
+    color: var(--text-normal);
   }
 </style>

--- a/src/ui/Reminder.svelte
+++ b/src/ui/Reminder.svelte
@@ -22,6 +22,14 @@
   // Off by default so a stray Enter/Space keypress right after the popup
   // appears doesn't accidentally complete a reminder the user hasn't read.
   export let focusDone: boolean = false;
+  // Whether keyboard mnemonics are active for this instance. Only relevant
+  // to the toast variant: multiple toasts can be shown at once, and each one
+  // mounts its own `svelte:window` keydown handler, so if more than one had
+  // shortcuts enabled a single keypress would trigger all of them at once.
+  // `ReminderToastManager` keeps this true for only the most recently shown
+  // toast. The modal variant never passes this prop, so it stays `true` and
+  // its behavior is unchanged.
+  export let shortcutsEnabled: boolean = true;
   // Do not set initial value so that svelte can render the placeholder `Remind Me Later`.
   let selectedIndex: number;
   export let laters: Array<Later> = [];
@@ -44,10 +52,9 @@
   // managers, launchers) intercept Option/Alt chords before they reach
   // Obsidian -- common on macOS, where Ctrl+letter is nearly always free.
   function handleKeydown(evt: KeyboardEvent) {
-    if (variant === "toast") {
-      // Multiple toasts can be shown at once; if each registered these
-      // shortcuts, one keypress would trigger all of them. Toasts are
-      // operated with the mouse/touch only.
+    if (!shortcutsEnabled) {
+      // See the `shortcutsEnabled` prop doc: only the most recently shown
+      // toast has this true. Older toasts fall back to mouse/touch only.
       return;
     }
     const alt = evt.altKey && !evt.ctrlKey;
@@ -100,8 +107,9 @@
 
 <!-- Capture phase so the shortcuts run before Obsidian's own keymap/hotkey
 handlers (e.g. Ctrl+O would otherwise also trigger the quick switcher).
-`<svelte:window>` can't be placed inside an `{#if}` block, so the toast
-variant is excluded inside `handleKeydown` itself instead. -->
+`<svelte:window>` can't be placed inside an `{#if}` block, so disabled
+instances (older toasts; see `shortcutsEnabled`) are excluded inside
+`handleKeydown` itself instead. -->
 <svelte:window on:keydown|capture={handleKeydown} />
 
 <main bind:this={containerEl} tabindex="-1" class:toast={variant === "toast"}>

--- a/src/ui/Reminder.svelte
+++ b/src/ui/Reminder.svelte
@@ -167,22 +167,24 @@ instances (older toasts; see `shortcutsEnabled`) are excluded inside
       {/each}
     </select>
   </div>
-  <div class="reminder-secondary-actions">
-    <button
-      class="reminder-footer-action"
-      on:click={onPauseAllNotifications}
-      title="Pause all notifications for a chosen duration. Reminders are not muted: anything still overdue notifies you again after the pause ends."
-    >
-      Pause all notifications…
-    </button>
-    <button
-      class="reminder-footer-action"
-      on:click={onMuteAll}
-      title="Mute every currently overdue reminder. Muted reminders stay silent (even across restarts) until you snooze them or change their date."
-    >
-      Mute all reminders…
-    </button>
-  </div>
+  {#if variant === "modal"}
+    <div class="reminder-secondary-actions">
+      <button
+        class="reminder-footer-action"
+        on:click={onPauseAllNotifications}
+        title="Pause all notifications for a chosen duration. Reminders are not muted: anything still overdue notifies you again after the pause ends."
+      >
+        Pause all notifications…
+      </button>
+      <button
+        class="reminder-footer-action"
+        on:click={onMuteAll}
+        title="Mute every currently overdue reminder. Muted reminders stay silent (even across restarts) until you snooze them or change their date."
+      >
+        Mute all reminders…
+      </button>
+    </div>
+  {/if}
 </main>
 
 <style>
@@ -260,15 +262,45 @@ instances (older toasts; see `shortcutsEnabled`) are excluded inside
   }
 
   main.toast .reminder-actions {
-    margin-top: 0.5rem;
+    margin-top: 0.4rem;
+    gap: 0.4rem;
   }
 
-  main.toast .reminder-secondary-actions {
-    gap: 0.75rem;
+  main.toast .reminder-actions button,
+  main.toast .later-select {
+    font-size: var(--font-ui-small);
   }
 
-  main.toast .reminder-footer-action {
-    margin-top: 0.5rem;
+  main.toast .reminder-actions button {
+    padding: 2px 10px;
+  }
+
+  main.toast .reminder-file {
+    display: block;
+    width: 100%;
+    text-align: left;
+    text-decoration: none;
+  }
+
+  main.toast .reminder-file:hover {
+    text-decoration: underline;
+  }
+
+  main.toast .reminder-file :global(.icon-text) {
+    display: flex;
+    width: 100%;
+  }
+
+  main.toast .reminder-file :global(.icon) {
+    flex-shrink: 0;
+  }
+
+  main.toast .reminder-file :global(.text) {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .reminder-toast-close {


### PR DESCRIPTION
## Summary

Two UX improvements that make reminder notifications less intrusive, addressing the main pain point of the previous centered modal: it steals focus, forces an immediate response, and stacks up as sequential dialogs when several reminders fire at once.

### 1. Toast-style reminder popups (new default)

A new **Reminder popup style** setting (`notificationPopupStyle`, **default `toast`**) renders the built-in popup as a non-modal card stacked in the bottom-right corner. The previous centered modal remains available by setting it to `Modal (center dialog)`.

- Toasts never steal keyboard focus, so typing is never interrupted; cards stay until acted on (no auto-dismiss, since dismissing means muting).
- The card offers Done / Mute / Snooze / open note, plus an explicit × close button (= Mute, same semantics as closing the modal). The global "Pause all notifications / Mute all reminders" actions stay in the modal and the command palette rather than repeating on every stacked card. The file link truncates to one line (full path on hover) and the action row uses Obsidian's small UI font, keeping each card compact.
- Multiple due reminders stack vertically instead of queueing one modal after another (toasts skip the `beingDisplayed` serialization used by the modal flow; `notification-worker.ts` is unchanged).
- Toasts appear immediately even while you are typing: the Edit Detection Time deferral now applies only to the focus-stealing modal style (the notification worker asks a new `isPopupIntrusive()` dep, covered by new unit tests).
- Keyboard mnemonics (Alt/Ctrl+D/M/S/O) work on exactly one card — the most recently shown toast — so a single keypress can never trigger multiple stacked toasts. Older toasts are operated with the buttons.
- Implemented by reusing `Reminder.svelte` with a new `variant` prop; the modal variant's behavior is unchanged.
- The setting applies everywhere the built-in popup is shown: direct notification, system-notification click, and "Show popup together with system notification".

**Default rationale**: the setting key is new in this release, so no existing user has explicitly chosen a style yet — changing the default later would be indistinguishable from a user's explicit choice. The quieter style is safe as a default because toasts persist until acted on and the status bar badge (below) keeps unresolved reminders visible.

### 2. Overdue count in the status bar

A new **Show overdue count in status bar** setting (`showOverdueCountInStatusBar`, default on) adds a status bar item (`⏰ 3`) showing the number of overdue reminders (muted ones included). Clicking it opens the reminder list view. Hidden when nothing is overdue.

This acts as the safety net for the quieter toast style: even if a notification is dismissed or missed, the unresolved count stays visible.

## Settings added

| Key | Type | Default |
| --- | --- | --- |
| `notificationPopupStyle` | dropdown (`toast` / `modal`) | `toast` |
| `showOverdueCountInStatusBar` | toggle | `true` |

Docs updated: `docs/src/setting/README.md`, `docs/src/guide/notification.md`.

## Release note

Since this changes the default notification presentation for all users, this should ship as a **minor** release (`gh workflow run release.yml -f bump=minor`), with release notes calling out that the previous modal behavior is one setting away (`Reminder popup style` → `Modal (center dialog)`).

## Verification

- `mise run pre-commit`: eslint + tsc + svelte-check clean (473 files), jest 13 suites / 148 tests passed.
- `mise run main:build`: production build succeeds.
- New code lives under `src/plugin/ui/` (imports `obsidian`), so per this repo's testing convention it has no unit tests; manual verification in a real vault (toast stacking, focus behavior, newest-toast shortcuts, theme chrome, status bar click) is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



