### PR TITLE
Add Dataview format (inline fields) as a new reminder format

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -76,6 +76,7 @@ module.exports = {
           collapsable: false,
           children: [
             'interop-tasks',
+            'interop-dataview',
             'interop-kanban',
             'interop-nldates'
           ]

--- a/docs/src/guide/interop-dataview.md
+++ b/docs/src/guide/interop-dataview.md
@@ -1,0 +1,100 @@
+# Dataview Format
+
+The Tasks plugin's "dataview format" (also usable on its own, without the
+Tasks plugin, since [Dataview](https://github.com/blacksmithgu/obsidian-dataview)
+inline fields are plain text) writes task metadata as inline fields instead
+of emoji:
+
+```markdown
+- [ ] Buy milk [due:: 2025-05-17]
+```
+
+If you enable [this setting](/setting/#enable-dataview-format), the above
+line is recognized as a reminder, firing on 2025-05-17 at the [default
+reminder time](/setting/#reminder-time).
+
+Neither the Tasks plugin nor Dataview needs to be installed: this plugin
+only reads and writes the `[key:: value]` text, so enabling this format
+never depends on any other plugin.
+
+## Field table
+
+| Field | Meaning |
+| --- | --- |
+| `due` | Due date. Used as the reminder date when no reminder field (below) is present. |
+| [reminder field name](/setting/#reminder-field-name) (default `reminder`) | A reminder date/time distinct from `due`. When present on a line, it wins over `due` for that line — no global toggle needed, unlike the Tasks plugin's own ⏰/📅 distinction. |
+| `completion` | Written automatically when the task is marked done. |
+| `repeat` | Recurrence text (e.g. `every week`), same syntax as the Tasks plugin's 🔁. |
+| `scheduled`, `start` | Recognized so they're stripped from the notification title, but otherwise unused. |
+
+Fields can be written with either delimiter style:
+
+```markdown
+- [ ] Buy milk [due:: 2025-05-17]
+- [ ] Buy milk (due:: 2025-05-17)
+```
+
+Any other inline field (e.g. `[priority:: high]`) is left untouched in the
+notification title.
+
+## Time part
+
+Like the [Tasks plugin format](/guide/interop-tasks.html), a time can be
+added to the due date or the reminder field:
+
+```markdown
+- [ ] Buy milk [due:: 2025-05-17T09:00]
+- [ ] Buy milk [due:: 2025-05-17 09:00]
+```
+
+Both the `T`-separated (Dataview's native datetime shape) and the
+space-separated shapes are accepted when reading. When the plugin itself
+writes a value back (snooze, calendar popup, recurrence), it always uses
+the `T`-separated shape so the value stays parsable by Dataview as a real
+datetime.
+
+::: warning Note
+Field values are parsed strictly as `YYYY-MM-DDTHH:mm`, `YYYY-MM-DD HH:mm`,
+or `YYYY-MM-DD`. Any other value (including trailing garbage) is ignored —
+that line simply won't produce a reminder. This format isn't affected by
+the [Strict Date format](/setting/#strict-date-format) setting, since these
+values are machine-formatted to begin with.
+:::
+
+## Distinguish due date and reminder date
+
+Set the [reminder field name](/setting/#reminder-field-name) (default
+`reminder`) and add that field to a line that also has `due`:
+
+```markdown
+- [ ] Buy milk [reminder:: 2025-05-16 18:00] [due:: 2025-05-17]
+```
+
+The reminder fires on 2025-05-16 18:00 (not 2025-05-17). Snoozing this
+reminder rewrites the `reminder` field, leaving `due` untouched.
+
+## Recurring tasks
+
+```markdown
+- [ ] Buy milk [repeat:: every week] [due:: 2025-05-17]
+```
+
+When you [toggle checklist status](/guide/set-reminders.html#toggle-checklist-status),
+the next occurrence is inserted above (with `due`, and the reminder field
+when present, both advanced), and the completed line gets a `completion`
+field:
+
+```markdown
+- [ ] Buy milk [repeat:: every week] [due:: 2025-05-24]
+- [x] Buy milk [repeat:: every week] [due:: 2025-05-17] [completion:: 2025-05-17]
+```
+
+## Works with the Tasks plugin's Dataview task format
+
+This is the same syntax the Tasks plugin itself writes when its own [Task
+format setting](https://publish.obsidian.md/tasks/Reference/Task+Formats/About+Task+Formats)
+is set to "Dataview". If you already use the Tasks plugin in that mode,
+enabling this format is all that's needed for its tasks to also produce
+reminders — see the [Tasks plugin
+guide](/guide/interop-tasks.html#using-the-tasks-plugin-s-dataview-task-format)
+for the reverse pointer.

--- a/docs/src/guide/interop-tasks.md
+++ b/docs/src/guide/interop-tasks.md
@@ -67,3 +67,10 @@ You can't insert any characters other than date/time between ⏰ and 📅.
 - (OK) `- [ ] Task ⏰ 2021-09-16 📅 2021-09-17`
 - (NG) `- [ ] Task ⏰ 2021-09-16 #Tag 📅 2021-09-17`
 :::
+
+## Using the Tasks plugin's Dataview task format
+
+The Tasks plugin also supports writing task metadata as Dataview inline
+fields (`[due:: 2021-09-16]`) instead of emoji. This plugin reads that
+syntax through a separate format — see the [Dataview
+format](/guide/interop-dataview.html) guide.

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -62,6 +62,7 @@ Reminder format for generated reminder by calendar popup.
   - [Reminder plugin format](/guide/set-reminders.html#reminder-format)
   - [Tasks plugin format](/guide/interop-tasks.html)
   - [Kanban plugin format](/guide/interop-kanban.html)
+  - [Dataview format](/guide/interop-dataview.html)
 
 ## Show reminder pills in editor
 
@@ -205,6 +206,27 @@ This setting affects only tasks plugin format.
 - Values:
   - ON: Tags are removed
   - OFF: Tags are not removed (default)
+
+## Enable Dataview format
+
+Enable support for the [Dataview format](/guide/interop-dataview.html)
+(`[due:: 2021-09-08]`), including the Tasks plugin's own Dataview task
+format.
+
+- Type: `boolean`
+- Values:
+  - ON: Enable Dataview format
+  - OFF: Disable Dataview format (default)
+
+## Reminder field name
+
+The name of the inline field (e.g. `[reminder:: 2021-09-08]`) read as the
+reminder date. On a line that also has a `due` field, this field takes
+precedence — see [Distinguish due date and reminder
+date](/guide/interop-dataview.html#distinguish-due-date-and-reminder-date).
+
+- Type: `string`
+- Default: `reminder`
 
 ## Enable Kanban plugin format
 

--- a/src/model/format/index.ts
+++ b/src/model/format/index.ts
@@ -7,6 +7,7 @@ import type {
   ReminderSpan,
 } from "./reminder-base";
 import { CompositeReminderFormat } from "./reminder-base";
+import { DataviewReminderFormat } from "./reminder-dataview";
 import { DefaultReminderFormat } from "./reminder-default";
 import { KanbanReminderFormat } from "./reminder-kanban-plugin";
 import { TasksPluginFormat } from "./reminder-tasks-plugin";
@@ -71,11 +72,19 @@ export const kanbanPluginReminderFormat = new ReminderFormatType(
   KanbanReminderFormat.instance,
   false,
 );
+export const dataviewReminderFormat = new ReminderFormatType(
+  "DataviewReminderFormat",
+  "Dataview format",
+  "[due:: 2021-09-08]",
+  DataviewReminderFormat.instance,
+  false,
+);
 
 export const ReminderFormatTypes = [
   reminderPluginReminderFormat,
   tasksPluginReminderFormat,
   kanbanPluginReminderFormat,
+  dataviewReminderFormat,
 ];
 
 export { MarkdownDocument };

--- a/src/model/format/inline-field.test.ts
+++ b/src/model/format/inline-field.test.ts
@@ -1,0 +1,197 @@
+import {
+  appendField,
+  parseInlineFields,
+  removeField,
+  replaceFieldValue,
+} from "./inline-field";
+
+describe("parseInlineFields()", (): void => {
+  test("bracket style", (): void => {
+    const fields = parseInlineFields("Buy milk [due:: 2025-05-17]");
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual({
+      key: "due",
+      value: "2025-05-17",
+      style: "bracket",
+      start: 9,
+      end: 27,
+    });
+    expect("Buy milk [due:: 2025-05-17]".slice(9, 27)).toBe(
+      "[due:: 2025-05-17]",
+    );
+  });
+
+  test("paren style", (): void => {
+    const fields = parseInlineFields("Buy milk (due:: 2025-05-17T09:00)");
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toEqual({
+      key: "due",
+      value: "2025-05-17T09:00",
+      style: "paren",
+      start: 9,
+      end: 33,
+    });
+  });
+
+  test("multiple fields, in document order", (): void => {
+    const fields = parseInlineFields(
+      "Task [due:: 2025-05-17] [repeat:: every week]",
+    );
+    expect(fields.map((f) => f.key)).toEqual(["due", "repeat"]);
+    expect(fields.map((f) => f.value)).toEqual(["2025-05-17", "every week"]);
+  });
+
+  test("multiple fields with the same key: both are returned, in order", (): void => {
+    const fields = parseInlineFields(
+      "Task [due:: 2025-05-17] [due:: 2025-06-01]",
+    );
+    expect(fields.map((f) => f.value)).toEqual(["2025-05-17", "2025-06-01"]);
+  });
+
+  test("key is case-sensitive as stored (case-insensitive lookup is a consumer concern)", (): void => {
+    const fields = parseInlineFields("Task [DUE:: 2025-05-17]");
+    expect(fields[0]!.key).toBe("DUE");
+  });
+
+  test("unicode key characters are accepted", (): void => {
+    const fields = parseInlineFields("Task [締切:: 2025-05-17]");
+    expect(fields[0]!.key).toBe("締切");
+  });
+
+  test("value is trimmed of surrounding whitespace inside the delimiters", (): void => {
+    const fields = parseInlineFields("Task [due::   2025-05-17   ]");
+    expect(fields[0]!.value).toBe("2025-05-17");
+  });
+
+  test("no space around :: is accepted", (): void => {
+    const fields = parseInlineFields("Task [due::2025-05-17]");
+    expect(fields[0]!.value).toBe("2025-05-17");
+  });
+
+  test("no fields present", (): void => {
+    expect(parseInlineFields("Just a plain task")).toEqual([]);
+  });
+
+  test("mismatched delimiters are not a field", (): void => {
+    expect(parseInlineFields("Task [due:: 2025-05-17)")).toEqual([]);
+    expect(parseInlineFields("Task (due:: 2025-05-17]")).toEqual([]);
+  });
+
+  test("key with invalid characters is not a field", (): void => {
+    expect(parseInlineFields("Task [du#e:: 2025-05-17]")).toEqual([]);
+  });
+
+  test("empty value is accepted", (): void => {
+    const fields = parseInlineFields("Task [due::]");
+    expect(fields[0]!.value).toBe("");
+  });
+
+  test("plain [[wikilink]] is not mistaken for a field", (): void => {
+    expect(parseInlineFields("Task [[Some Note]]")).toEqual([]);
+  });
+});
+
+describe("replaceFieldValue()", (): void => {
+  test("bracket style: replaces only the value, preserving everything else", (): void => {
+    const text = "Buy milk [due:: 2025-05-17] #tag";
+    const field = parseInlineFields(text)[0]!;
+    expect(replaceFieldValue(text, field, "2025-06-01")).toBe(
+      "Buy milk [due:: 2025-06-01] #tag",
+    );
+  });
+
+  test("paren style is preserved", (): void => {
+    const text = "Buy milk (due:: 2025-05-17)";
+    const field = parseInlineFields(text)[0]!;
+    expect(replaceFieldValue(text, field, "2025-05-17T09:00")).toBe(
+      "Buy milk (due:: 2025-05-17T09:00)",
+    );
+  });
+
+  test("unusual spacing around :: is preserved", (): void => {
+    const text = "Buy milk [due::   2025-05-17   ]";
+    const field = parseInlineFields(text)[0]!;
+    expect(replaceFieldValue(text, field, "2025-06-01")).toBe(
+      "Buy milk [due::   2025-06-01   ]",
+    );
+  });
+
+  test("no space around :: is preserved", (): void => {
+    const text = "Buy milk [due::2025-05-17]";
+    const field = parseInlineFields(text)[0]!;
+    expect(replaceFieldValue(text, field, "2025-06-01")).toBe(
+      "Buy milk [due::2025-06-01]",
+    );
+  });
+
+  test("replacing one field doesn't disturb another field later in the line", (): void => {
+    const text = "Task [due:: 2025-05-17] [repeat:: every week]";
+    const dueField = parseInlineFields(text)[0]!;
+    const updated = replaceFieldValue(text, dueField, "2025-06-01");
+    expect(updated).toBe("Task [due:: 2025-06-01] [repeat:: every week]");
+    const repeatField = parseInlineFields(updated)[1]!;
+    expect(repeatField.value).toBe("every week");
+  });
+});
+
+describe("appendField()", (): void => {
+  test("appends a bracket-style field with a separating space", (): void => {
+    expect(appendField("Buy milk", "due", "2025-05-17")).toBe(
+      "Buy milk [due:: 2025-05-17]",
+    );
+  });
+
+  test("appends a paren-style field when requested", (): void => {
+    expect(appendField("Buy milk", "due", "2025-05-17", "paren")).toBe(
+      "Buy milk (due:: 2025-05-17)",
+    );
+  });
+
+  test("doesn't double up a trailing space", (): void => {
+    expect(appendField("Buy milk ", "due", "2025-05-17")).toBe(
+      "Buy milk [due:: 2025-05-17]",
+    );
+  });
+
+  test("empty text: no leading separator", (): void => {
+    expect(appendField("", "due", "2025-05-17")).toBe("[due:: 2025-05-17]");
+  });
+
+  test("round-trips through parseInlineFields()", (): void => {
+    const text = appendField("Buy milk", "due", "2025-05-17");
+    const fields = parseInlineFields(text);
+    expect(fields).toHaveLength(1);
+    expect(fields[0]!.key).toBe("due");
+    expect(fields[0]!.value).toBe("2025-05-17");
+    expect(text.slice(fields[0]!.start, fields[0]!.end)).toBe(
+      "[due:: 2025-05-17]",
+    );
+  });
+});
+
+describe("removeField()", (): void => {
+  test("removes the field and a preceding separating space", (): void => {
+    const text = "Buy milk [due:: 2025-05-17] #tag";
+    const field = parseInlineFields(text)[0]!;
+    expect(removeField(text, field)).toBe("Buy milk #tag");
+  });
+
+  test("removes the field and a following separating space when there's nothing before it", (): void => {
+    const text = "[due:: 2025-05-17] Buy milk";
+    const field = parseInlineFields(text)[0]!;
+    expect(removeField(text, field)).toBe("Buy milk");
+  });
+
+  test("removes a field that is the entire text", (): void => {
+    const text = "[due:: 2025-05-17]";
+    const field = parseInlineFields(text)[0]!;
+    expect(removeField(text, field)).toBe("");
+  });
+
+  test("removing one field leaves another field's own text intact", (): void => {
+    const text = "Task [due:: 2025-05-17] [repeat:: every week]";
+    const dueField = parseInlineFields(text)[0]!;
+    const updated = removeField(text, dueField);
+    expect(updated).toBe("Task [repeat:: every week]");
+  });
+});

--- a/src/model/format/inline-field.ts
+++ b/src/model/format/inline-field.ts
@@ -1,0 +1,148 @@
+/**
+ * A small tokenizer for Dataview-style inline fields on a single line, e.g.
+ * `[due:: 2025-05-17]` or `(due:: 2025-05-17T09:00)`.
+ *
+ * This is the analogue of `splitter.ts` for the Dataview format: it doesn't
+ * know anything about reminders, dates, or the Tasks plugin. It only
+ * recognizes the generic `[key:: value]` / `(key:: value)` shape and gives
+ * callers exact original-text coordinates so a caller-side `computeSpan()`
+ * can point at the right place in the editor.
+ *
+ * Key match is case-sensitive here: this module stores the key exactly as
+ * written. Callers that need case-insensitive lookups (Dataview itself
+ * normalizes keys) should lowercase both sides when comparing.
+ */
+
+export type InlineFieldStyle = "bracket" | "paren";
+
+export type InlineField = {
+  /** The field key, exactly as written (not case-normalized). */
+  key: string;
+  /** The field value, with surrounding whitespace (inside the delimiters) trimmed. */
+  value: string;
+  /** Whether the field was written as `[key:: value]` or `(key:: value)`. */
+  style: InlineFieldStyle;
+  /** Start index (inclusive) of the whole field, in original-text UTF-16 coordinates. */
+  start: number;
+  /** End index (exclusive) of the whole field, in original-text UTF-16 coordinates. */
+  end: number;
+};
+
+// Decomposes a field into its structural parts so that `replaceFieldValue`
+// can splice in a new value while preserving everything else byte-for-byte
+// (including any unusual spacing around `::` that a user may have written).
+//
+//   open   pre       key            mid  value                 post      close
+//   [/(    \s*   [\p{L}\p{N}_-]+   ::  \s*   [^[\]()]* (lazy)   \s*      ]/)
+const INLINE_FIELD_SOURCE =
+  "(?<open>[[(])(?<pre>\\s*)(?<key>[\\p{L}\\p{N}_-]+)::(?<mid>\\s*)(?<value>[^[\\]()]*?)(?<post>\\s*)(?<close>[)\\]])";
+
+function matchesStyle(open: string, close: string): InlineFieldStyle | null {
+  if (open === "[" && close === "]") {
+    return "bracket";
+  }
+  if (open === "(" && close === ")") {
+    return "paren";
+  }
+  // Mismatched delimiters (e.g. `[due:: 2025-05-17)`) are not a valid field.
+  return null;
+}
+
+/**
+ * Parse all inline fields out of `text`, in original-text coordinates.
+ *
+ * Fields are matched independently of each other (no nesting support is
+ * needed for task metadata); when the same key appears multiple times, all
+ * occurrences are returned in document order, and it's up to the caller to
+ * decide that "the first one wins" where that matters.
+ */
+export function parseInlineFields(text: string): InlineField[] {
+  const regexp = new RegExp(INLINE_FIELD_SOURCE, "gu");
+  const fields: InlineField[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regexp.exec(text)) !== null) {
+    const groups = match.groups!;
+    const style = matchesStyle(groups["open"]!, groups["close"]!);
+    if (style == null) {
+      continue;
+    }
+    fields.push({
+      key: groups["key"]!,
+      value: groups["value"]!,
+      style,
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+  return fields;
+}
+
+/**
+ * Replace the value of `field` (previously returned by `parseInlineFields`
+ * on this exact `text`) with `newValue`, preserving the delimiters, key,
+ * and any whitespace around `::` byte-for-byte.
+ */
+export function replaceFieldValue(
+  text: string,
+  field: InlineField,
+  newValue: string,
+): string {
+  const fieldText = text.slice(field.start, field.end);
+  const regexp = new RegExp(`^${INLINE_FIELD_SOURCE}$`, "u");
+  const match = regexp.exec(fieldText);
+  if (match == null) {
+    // Shouldn't happen for a field that came from parseInlineFields() on
+    // this same text, but fail safe by leaving the text untouched.
+    return text;
+  }
+  const groups = match.groups!;
+  const prefixLength =
+    groups["open"]!.length +
+    groups["pre"]!.length +
+    groups["key"]!.length +
+    2 /* "::" */ +
+    groups["mid"]!.length;
+  const valueLength = groups["value"]!.length;
+  const newFieldText =
+    fieldText.slice(0, prefixLength) +
+    newValue +
+    fieldText.slice(prefixLength + valueLength);
+  return text.slice(0, field.start) + newFieldText + text.slice(field.end);
+}
+
+/**
+ * Append a new field `[key:: value]` (or `(key:: value)` for `style ===
+ * "paren"`) at the end of `text`, matching what the Tasks plugin itself
+ * writes: a single separating space is inserted when `text` doesn't already
+ * end with whitespace, and nothing is inserted when `text` is empty.
+ */
+export function appendField(
+  text: string,
+  key: string,
+  value: string,
+  style: InlineFieldStyle = "bracket",
+): string {
+  const [open, close] = style === "bracket" ? ["[", "]"] : ["(", ")"];
+  const fieldText = `${open}${key}:: ${value}${close}`;
+  if (text.length === 0) {
+    return fieldText;
+  }
+  const separator = /\s$/.test(text) ? "" : " ";
+  return `${text}${separator}${fieldText}`;
+}
+
+/**
+ * Remove `field` (previously returned by `parseInlineFields` on this exact
+ * `text`) from `text`, also trimming one adjacent separating space (if any)
+ * so removal doesn't leave a double space behind.
+ */
+export function removeField(text: string, field: InlineField): string {
+  let start = field.start;
+  let end = field.end;
+  if (start > 0 && text[start - 1] === " ") {
+    start -= 1;
+  } else if (end < text.length && text[end] === " ") {
+    end += 1;
+  }
+  return text.slice(0, start) + text.slice(end);
+}

--- a/src/model/format/reminder-base.ts
+++ b/src/model/format/reminder-base.ts
@@ -50,6 +50,11 @@ export class ReminderFormatParameterKey<T> {
     );
   static readonly removeTagsForTasksPlugin =
     new ReminderFormatParameterKey<boolean>("removeTagsForTasksPlugin", false);
+  static readonly dataviewReminderFieldName =
+    new ReminderFormatParameterKey<string>(
+      "dataviewReminderFieldName",
+      "reminder",
+    );
   static readonly linkDatesToDailyNotes =
     new ReminderFormatParameterKey<boolean>("linkDatesToDailyNotes", false);
   static readonly strictDateFormat = new ReminderFormatParameterKey<boolean>(

--- a/src/model/format/reminder-dataview.test.ts
+++ b/src/model/format/reminder-dataview.test.ts
@@ -1,0 +1,302 @@
+import { MarkdownDocument } from "model/format/markdown";
+import { DateTime } from "model/time";
+import moment from "moment";
+import {
+  ReminderFormatConfig,
+  ReminderFormatParameterKey,
+} from "./reminder-base";
+import { ReminderFormatTestUtil } from "./reminder-base.test";
+import {
+  DataviewReminderFormat,
+  DataviewReminderModel,
+} from "./reminder-dataview";
+
+describe("DataviewReminderFormat", (): void => {
+  const util = new ReminderFormatTestUtil(() => new DataviewReminderFormat());
+
+  describe("parse()", (): void => {
+    test("date only, bracket style", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+        expectedSpan: { start: 15, end: 33 },
+      });
+    });
+
+    test("datetime, T-separated shape", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17T09:00]",
+        expectedTime: "2025-05-17 09:00",
+        expectedTitle: "Buy milk",
+        expectedSpan: { start: 15, end: 39 },
+      });
+    });
+
+    test("datetime, space-separated shape", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17 09:00]",
+        expectedTime: "2025-05-17 09:00",
+        expectedTitle: "Buy milk",
+        expectedSpan: { start: 15, end: 39 },
+      });
+    });
+
+    test("paren style", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk (due:: 2025-05-17)",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+        expectedSpan: { start: 15, end: 33 },
+      });
+    });
+
+    test("reminder field wins over due", (): void => {
+      util.testParse({
+        inputMarkdown:
+          "- [ ] Buy milk [due:: 2025-05-20] [reminder:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+        expectedSpan: { start: 34, end: 57 },
+      });
+    });
+
+    test("custom reminder field name wins over due", (): void => {
+      util.testParse({
+        inputMarkdown:
+          "- [ ] Buy milk [due:: 2025-05-20] [remind:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+        expectedSpan: { start: 34, end: 55 },
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.dataviewReminderFieldName,
+            "remind",
+          );
+        },
+      });
+    });
+
+    test("a differently-named field is not the reminder field by default (falls back to due, stays in title)", (): void => {
+      util.testParse({
+        inputMarkdown:
+          "- [ ] Buy milk [due:: 2025-05-20] [remind:: 2025-05-17]",
+        expectedTime: "2025-05-20",
+        expectedTitle: "Buy milk [remind:: 2025-05-17]",
+      });
+    });
+
+    test("unrecognized fields stay in the title", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk [priority:: high] [due:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk [priority:: high]",
+      });
+    });
+
+    test("recognized-but-unused fields (scheduled/start) are stripped from the title", (): void => {
+      util.testParse({
+        inputMarkdown:
+          "- [ ] Buy milk [scheduled:: 2025-05-15] [start:: 2025-05-14] [due:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+      });
+    });
+
+    test("multiple due fields: first wins", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17] [due:: 2025-06-01]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+      });
+    });
+
+    test("tag removal", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk #shopping [due:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk",
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.removeTagsForTasksPlugin,
+            true,
+          );
+        },
+      });
+    });
+
+    test("tags are kept by default", (): void => {
+      util.testParse({
+        inputMarkdown: "- [ ] Buy milk #shopping [due:: 2025-05-17]",
+        expectedTime: "2025-05-17",
+        expectedTitle: "Buy milk #shopping",
+      });
+    });
+
+    test("span slices to the exact field text", (): void => {
+      const inputMarkdown =
+        "- [ ] Buy milk [due:: 2025-05-20] [reminder:: 2025-05-17]";
+      const sut = new DataviewReminderFormat();
+      sut.setConfig(new ReminderFormatConfig());
+      const spans = sut.parse(new MarkdownDocument("file", inputMarkdown));
+      const span = spans[0]!;
+      expect(inputMarkdown.slice(span.columnStart, span.columnEnd)).toBe(
+        "[reminder:: 2025-05-17]",
+      );
+    });
+
+    test("fails closed: an unparsable due value yields no reminder", (): void => {
+      const sut = new DataviewReminderFormat();
+      sut.setConfig(new ReminderFormatConfig());
+      const spans = sut.parse(
+        new MarkdownDocument("file", "- [ ] Buy milk [due:: not-a-date]"),
+      );
+      expect(spans).toHaveLength(0);
+    });
+
+    test("fails closed: an unparsable reminder value does not fall back to a valid due value", (): void => {
+      const sut = new DataviewReminderFormat();
+      sut.setConfig(new ReminderFormatConfig());
+      const spans = sut.parse(
+        new MarkdownDocument(
+          "file",
+          "- [ ] Buy milk [due:: 2025-05-20] [reminder:: garbage]",
+        ),
+      );
+      expect(spans).toHaveLength(0);
+    });
+
+    test("no due or reminder field at all: not a reminder", (): void => {
+      const sut = new DataviewReminderFormat();
+      sut.setConfig(new ReminderFormatConfig());
+      const spans = sut.parse(
+        new MarkdownDocument("file", "- [ ] Buy milk [priority:: high]"),
+      );
+      expect(spans).toHaveLength(0);
+    });
+
+    test("non-task lines are ignored", (): void => {
+      const sut = new DataviewReminderFormat();
+      sut.setConfig(new ReminderFormatConfig());
+      const spans = sut.parse(
+        new MarkdownDocument("file", "Buy milk [due:: 2025-05-17]"),
+      );
+      expect(spans).toHaveLength(0);
+    });
+  });
+
+  describe("modify() - snooze", (): void => {
+    test("rewrites the due field in place, preserving bracket style", async () => {
+      await util.testModify({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17]",
+        edit: { time: new DateTime(moment("2025-05-20"), false) },
+        expectedMarkdown: "- [ ] Buy milk [due:: 2025-05-20]",
+      });
+    });
+
+    test("rewrites the due field in place, preserving paren style", async () => {
+      await util.testModify({
+        inputMarkdown: "- [ ] Buy milk (due:: 2025-05-17)",
+        edit: { time: new DateTime(moment("2025-05-20"), false) },
+        expectedMarkdown: "- [ ] Buy milk (due:: 2025-05-20)",
+      });
+    });
+
+    test("rewrites the reminder field (not due) when the reminder field is the source", async () => {
+      await util.testModify({
+        inputMarkdown:
+          "- [ ] Buy milk [due:: 2025-05-20] (reminder:: 2025-05-17)",
+        edit: { time: new DateTime(moment("2025-05-25 08:00"), true) },
+        expectedMarkdown:
+          "- [ ] Buy milk [due:: 2025-05-20] (reminder:: 2025-05-25T08:00)",
+      });
+    });
+
+    test("writes a time-bearing value with the T-separated shape", async () => {
+      await util.testModify({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17]",
+        edit: { time: new DateTime(moment("2025-05-20 09:30"), true) },
+        expectedMarkdown: "- [ ] Buy milk [due:: 2025-05-20T09:30]",
+      });
+    });
+  });
+
+  describe("modify() - done", (): void => {
+    test("writes a date-only completion field", async () => {
+      await util.testModify({
+        inputMarkdown: "- [ ] Buy milk [due:: 2025-05-17]",
+        edit: { checked: true },
+        expectedMarkdown:
+          "- [x] Buy milk [due:: 2025-05-17] [completion:: 2025-06-01]",
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.now,
+            new DateTime(moment("2025-06-01 10:00"), true),
+          );
+        },
+      });
+    });
+
+    test("unchecking removes the completion field", async () => {
+      await util.testModify({
+        inputMarkdown:
+          "- [x] Buy milk [due:: 2025-05-17] [completion:: 2025-06-01]",
+        edit: { checked: false },
+        expectedMarkdown: "- [ ] Buy milk [due:: 2025-05-17]",
+      });
+    });
+
+    test("recurrence: inserts the next occurrence and completes the current one", async () => {
+      await util.testModify({
+        inputMarkdown: "- [ ] Task [repeat:: every day] [due:: 2025-05-17]",
+        edit: { checked: true },
+        expectedMarkdown: `- [ ] Task [repeat:: every day] [due:: 2025-05-19]
+- [x] Task [repeat:: every day] [due:: 2025-05-17] [completion:: 2025-05-18]`,
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.now,
+            new DateTime(moment("2025-05-18"), true),
+          );
+        },
+      });
+    });
+
+    test("recurrence with a separate reminder field: both due and reminder advance", async () => {
+      await util.testModify({
+        inputMarkdown:
+          "- [ ] Task [repeat:: every day] [reminder:: 2025-05-17T09:00] [due:: 2025-05-17]",
+        edit: { checked: true },
+        expectedMarkdown: `- [ ] Task [repeat:: every day] [reminder:: 2025-05-19T09:00] [due:: 2025-05-19]
+- [x] Task [repeat:: every day] [reminder:: 2025-05-17T09:00] [due:: 2025-05-17] [completion:: 2025-05-18]`,
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.now,
+            new DateTime(moment("2025-05-18 08:00"), true),
+          );
+        },
+      });
+    });
+  });
+});
+
+describe("DataviewReminderModel", (): void => {
+  test("newReminder() appends a [due:: ...] field", (): void => {
+    const sut = new DataviewReminderFormat();
+    sut.setConfig(new ReminderFormatConfig());
+    const inserted = sut.appendReminder(
+      "- [ ] Buy milk",
+      new DateTime(moment("2025-05-17"), false),
+    );
+    expect(inserted!.insertedLine).toBe("- [ ] Buy milk [due:: 2025-05-17]");
+  });
+
+  test("clone() round-trips through toMarkdown()", (): void => {
+    const model = DataviewReminderModel.parse(
+      "Buy milk [due:: 2025-05-17]",
+      "reminder",
+    );
+    const clone = model.clone();
+    expect(clone.toMarkdown()).toBe(model.toMarkdown());
+    expect(clone.getTime()!.toString()).toBe("2025-05-17");
+  });
+});

--- a/src/model/format/reminder-dataview.ts
+++ b/src/model/format/reminder-dataview.ts
@@ -1,0 +1,279 @@
+import type { Todo } from "model/format/markdown";
+import { DateTime } from "model/time";
+import moment from "moment";
+import type { InlineField } from "./inline-field";
+import {
+  appendField,
+  parseInlineFields,
+  removeField,
+  replaceFieldValue,
+} from "./inline-field";
+import { ReminderFormatParameterKey } from "./reminder-base";
+import { TasksLikeReminderFormat, removeTags } from "./reminder-tasks-like";
+import type { TasksLikeReminderModel } from "./reminder-tasks-like";
+
+// Value parsing is strict-only, tried in this order (see design doc
+// "Syntax supported"). Unlike the Reminder plugin's own format, the global
+// `strictDateFormat` setting doesn't loosen this: dataview field values are
+// machine-formatted, so loose parsing would only reintroduce the class of
+// silently-wrong-time bugs this format is meant to avoid (#108).
+const DATE_TIME_FORMATS = ["YYYY-MM-DDTHH:mm", "YYYY-MM-DD HH:mm"];
+const DATE_FORMAT = "YYYY-MM-DD";
+
+function parseValue(raw: string): DateTime | null {
+  for (const format of DATE_TIME_FORMATS) {
+    const m = moment(raw, format, true);
+    if (m.isValid()) {
+      return new DateTime(m, true);
+    }
+  }
+  const m = moment(raw, DATE_FORMAT, true);
+  if (m.isValid()) {
+    return new DateTime(m, false);
+  }
+  return null;
+}
+
+function formatValue(time: DateTime): string {
+  if (time.hasTimePart) {
+    return time.format("YYYY-MM-DDTHH:mm");
+  }
+  return time.format(DATE_FORMAT);
+}
+
+const KEY_DUE = "due";
+const KEY_COMPLETION = "completion";
+const KEY_REPEAT = "repeat";
+const KEY_SCHEDULED = "scheduled";
+const KEY_START = "start";
+// Recognized-but-unused fields: kept out of the title (like the other
+// recognized fields), but otherwise not read or written by this format.
+const RECOGNIZED_KEYS = [
+  KEY_DUE,
+  KEY_COMPLETION,
+  KEY_REPEAT,
+  KEY_SCHEDULED,
+  KEY_START,
+];
+
+export class DataviewReminderModel implements TasksLikeReminderModel {
+  public static parse(
+    line: string,
+    reminderFieldName: string,
+    removeTags?: boolean,
+  ): DataviewReminderModel {
+    return new DataviewReminderModel(
+      line,
+      reminderFieldName.toLowerCase(),
+      removeTags ?? false,
+    );
+  }
+
+  private constructor(
+    private text: string,
+    private reminderFieldName: string,
+    private removeTags: boolean,
+  ) {}
+
+  private fields(): InlineField[] {
+    return parseInlineFields(this.text);
+  }
+
+  private fieldsByKey(key: string): InlineField[] {
+    return this.fields().filter((f) => f.key.toLowerCase() === key);
+  }
+
+  private firstField(key: string): InlineField | null {
+    return this.fieldsByKey(key)[0] ?? null;
+  }
+
+  /** Whether this line has a reminder field distinct from `due`. */
+  hasReminderField(): boolean {
+    return this.firstField(this.reminderFieldName) != null;
+  }
+
+  /** Whether this line carries either a reminder field or a `due` field at all. */
+  hasAnySourceField(): boolean {
+    return this.hasReminderField() || this.firstField(KEY_DUE) != null;
+  }
+
+  /**
+   * The field this reminder's time is read from / written to: the
+   * configured reminder field when present, otherwise `due`. Per-line rule
+   * — no global toggle, unlike the Tasks plugin's emoji format.
+   */
+  private reminderSourceField(): InlineField | null {
+    return this.firstField(this.reminderFieldName) ?? this.firstField(KEY_DUE);
+  }
+
+  getTitle(): string | null {
+    const keysToStrip = new Set<string>([
+      ...RECOGNIZED_KEYS,
+      this.reminderFieldName,
+    ]);
+    // Remove fields right-to-left so earlier (untouched) fields keep their
+    // original indices valid while later ones are removed.
+    const toRemove = this.fields()
+      .filter((f) => keysToStrip.has(f.key.toLowerCase()))
+      .sort((a, b) => b.start - a.start);
+    let result = this.text;
+    for (const field of toRemove) {
+      result = removeField(result, field);
+    }
+    result = result.trim();
+    if (this.removeTags) {
+      result = removeTags(result);
+    }
+    return result;
+  }
+
+  getTime(): DateTime | null {
+    const field = this.reminderSourceField();
+    if (field == null) {
+      return null;
+    }
+    return parseValue(field.value);
+  }
+
+  setTime(time: DateTime): void {
+    const field = this.reminderSourceField();
+    const key = field?.key ?? KEY_DUE;
+    this.setFieldValue(key, formatValue(time));
+  }
+
+  setRawTime(rawTime: string): boolean {
+    const field = this.reminderSourceField();
+    const key = field?.key ?? KEY_DUE;
+    this.setFieldValue(key, rawTime);
+    return true;
+  }
+
+  getDueDate(): DateTime | null {
+    const field = this.firstField(KEY_DUE);
+    if (field == null) {
+      return null;
+    }
+    return parseValue(field.value);
+  }
+
+  setDueDate(time: DateTime): void {
+    this.setFieldValue(KEY_DUE, formatValue(time));
+  }
+
+  getRecurrence(): string | null {
+    const field = this.firstField(KEY_REPEAT);
+    return field?.value ?? null;
+  }
+
+  getDoneDate(): DateTime | null {
+    const field = this.firstField(KEY_COMPLETION);
+    if (field == null) {
+      return null;
+    }
+    return parseValue(field.value);
+  }
+
+  setDoneDate(time: DateTime | string | undefined): void {
+    if (time == null) {
+      this.removeFieldByKey(KEY_COMPLETION);
+      return;
+    }
+    // Completion date is always written date-only, mirroring the Tasks
+    // plugin's own ✅ semantics (see the Tasks-plugin emoji format's
+    // setDoneDate, which likewise ignores the incoming DateTime's time
+    // part).
+    const value = time instanceof DateTime ? time.format(DATE_FORMAT) : time;
+    this.setFieldValue(KEY_COMPLETION, value);
+  }
+
+  getEndOfTimeTextIndex(): number {
+    const field = this.reminderSourceField();
+    if (field != null) {
+      return field.end;
+    }
+    return this.toMarkdown().length;
+  }
+
+  computeSpan(): { start: number; end: number } {
+    const field = this.reminderSourceField();
+    if (field == null) {
+      return { start: 0, end: 0 };
+    }
+    return { start: field.start, end: field.end };
+  }
+
+  toMarkdown(): string {
+    return this.text;
+  }
+
+  clone(): DataviewReminderModel {
+    return DataviewReminderModel.parse(
+      this.toMarkdown(),
+      this.reminderFieldName,
+      this.removeTags,
+    );
+  }
+
+  private setFieldValue(key: string, newValue: string): void {
+    const field = this.firstField(key);
+    if (field != null) {
+      this.text = replaceFieldValue(this.text, field, newValue);
+    } else {
+      this.text = appendField(this.text, key, newValue, "bracket");
+    }
+  }
+
+  private removeFieldByKey(key: string): void {
+    const field = this.firstField(key);
+    if (field != null) {
+      this.text = removeField(this.text, field);
+    }
+  }
+}
+
+export class DataviewReminderFormat extends TasksLikeReminderFormat<DataviewReminderModel> {
+  public static readonly instance = new DataviewReminderFormat();
+
+  parseReminder(todo: Todo): DataviewReminderModel | null {
+    const parsed = DataviewReminderModel.parse(
+      todo.body,
+      this.reminderFieldName(),
+      this.removeTagsEnabled(),
+    );
+    if (!parsed.hasAnySourceField()) {
+      return null;
+    }
+    return parsed;
+  }
+
+  private reminderFieldName(): string {
+    return this.config.getParameter(
+      ReminderFormatParameterKey.dataviewReminderFieldName,
+    );
+  }
+
+  private removeTagsEnabled(): boolean {
+    return this.config.getParameter(
+      ReminderFormatParameterKey.removeTagsForTasksPlugin,
+    );
+  }
+
+  protected override usesSeparateReminderDate(
+    parsed: DataviewReminderModel,
+  ): boolean {
+    return parsed.hasReminderField();
+  }
+
+  newReminder(title: string, time: DateTime): DataviewReminderModel {
+    const parsed = DataviewReminderModel.parse(
+      title,
+      this.reminderFieldName(),
+      this.removeTagsEnabled(),
+    );
+    // Unlike the Reminder plugin's own format, the Dataview format never
+    // inserts at a caret position within the title: fields are always
+    // appended at the end of the line, so `insertAt` doesn't apply here.
+    parsed.setTime(time);
+    return parsed;
+  }
+}

--- a/src/model/format/reminder-tasks-like.ts
+++ b/src/model/format/reminder-tasks-like.ts
@@ -1,0 +1,133 @@
+import type { MarkdownDocument, Todo } from "model/format/markdown";
+import { DateTime } from "model/time";
+import moment from "moment";
+import { nextOccurrence } from "./recurrence";
+import {
+  ReminderFormatParameterKey,
+  TodoBasedReminderFormat,
+} from "./reminder-base";
+import type { ReminderEdit, ReminderModel } from "./reminder-base";
+
+/**
+ * Strip Obsidian tags (`#tag`, including nested `#tag/sub` and non-ASCII
+ * tags) from `text`. Shared by every format whose title may carry the
+ * user's own tags inline (Tasks plugin emoji format, Dataview format).
+ */
+export function removeTags(text: string): string {
+  // Obsidian tags may contain any letters and digits (including non-ASCII
+  // characters), plus "-", "_" and "/" for nested tags.
+  return text.replace(/#[\p{L}\p{N}\p{M}_/-]+/gu, "").trim();
+}
+
+/**
+ * The narrow model surface that the Tasks-plugin-compatible recurrence-on-
+ * done logic (`TasksLikeReminderFormat.modifyReminder`) depends on. Both the
+ * Tasks plugin's emoji format and the Dataview format implement this, each
+ * over their own line syntax (see `reminder-tasks-plugin.ts` /
+ * `reminder-dataview.ts`).
+ */
+export interface TasksLikeReminderModel extends ReminderModel {
+  getDueDate(): DateTime | null;
+  setDueDate(time: DateTime): void;
+  getRecurrence(): string | null;
+  setDoneDate(time: DateTime | string | undefined): void;
+  clone(): TasksLikeReminderModel;
+}
+
+/**
+ * Hosts the recurrence-on-done semantics shared by every Tasks-plugin-
+ * compatible format: on completion, compute the next occurrence from the
+ * recurrence text, clone the todo, insert the clone above as the new
+ * (unchecked) occurrence, and stamp the completed line with its done date.
+ *
+ * The one behavior that differs between concrete formats is whether the
+ * reminder date is tracked separately from the due date (the Tasks plugin's
+ * emoji format needs a global toggle for this; the Dataview format decides
+ * per-line, based on which fields are present) — that's factored out into
+ * `usesSeparateReminderDate()`.
+ */
+export abstract class TasksLikeReminderFormat<
+  M extends TasksLikeReminderModel,
+> extends TodoBasedReminderFormat<M> {
+  override modifyReminder(
+    doc: MarkdownDocument,
+    todo: Todo,
+    parsed: M,
+    edit: ReminderEdit,
+  ): boolean {
+    if (!super.modifyReminder(doc, todo, parsed, edit)) {
+      return false;
+    }
+    if (edit.checked !== undefined) {
+      if (edit.checked) {
+        const recurrence = parsed.getRecurrence();
+        if (recurrence !== null) {
+          const nextReminderTodo = todo.clone()!;
+          const nextReminder = parsed.clone();
+          const dueDate = parsed.getDueDate();
+          if (dueDate == null) {
+            return false;
+          }
+
+          const now = this.config.getParameter(ReminderFormatParameterKey.now);
+          if (this.usesSeparateReminderDate(parsed)) {
+            const time = parsed.getTime();
+            if (time == null) {
+              return false;
+            }
+            const nextTime: Date | undefined = nextOccurrence(
+              recurrence,
+              time.moment(),
+              now,
+            );
+            const nextDueDate: Date | undefined = nextOccurrence(
+              recurrence,
+              dueDate.moment(),
+              now,
+            );
+            if (nextTime == null || nextDueDate == null) {
+              return false;
+            }
+            nextReminder.setTime(new DateTime(moment(nextTime), true));
+            nextReminder.setDueDate(
+              new DateTime(moment(nextDueDate), dueDate.hasTimePart),
+            );
+          } else {
+            const next: Date | undefined = nextOccurrence(
+              recurrence,
+              dueDate.moment(),
+              now,
+            );
+            if (next == null) {
+              return false;
+            }
+            const nextDueDate = new DateTime(moment(next), dueDate.hasTimePart);
+            nextReminder.setTime(nextDueDate);
+          }
+          nextReminderTodo.body = nextReminder.toMarkdown();
+          nextReminderTodo.setChecked(false);
+          doc.insertTodo(todo.lineIndex, nextReminderTodo);
+        }
+        parsed.setDoneDate(
+          this.config.getParameter(ReminderFormatParameterKey.now),
+        );
+      } else {
+        parsed.setDoneDate(undefined);
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Whether `parsed`'s reminder date should be tracked (and advanced on
+   * recurrence) separately from its due date.
+   *
+   * - The Tasks plugin's emoji format returns a global setting
+   *   (`useCustomEmojiForTasksPlugin`): it's an all-or-nothing toggle
+   *   because the emoji vocabulary (⏰ vs 📅) doesn't vary per line.
+   * - The Dataview format returns whether *this line* has a distinct
+   *   reminder field: field names are explicit per line, so no global
+   *   toggle is needed.
+   */
+  protected abstract usesSeparateReminderDate(parsed: M): boolean;
+}

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -1,20 +1,12 @@
-import type { MarkdownDocument, Todo } from "model/format/markdown";
+import type { Todo } from "model/format/markdown";
 import { DATE_TIME_FORMATTER, DateTime } from "model/time";
 import moment from "moment";
-import { nextOccurrence } from "./recurrence";
-import {
-  ReminderFormatParameterKey,
-  TodoBasedReminderFormat,
-} from "./reminder-base";
-import type { ReminderEdit, ReminderModel } from "./reminder-base";
+import { ReminderFormatParameterKey } from "./reminder-base";
+import { TasksLikeReminderFormat, removeTags } from "./reminder-tasks-like";
+import type { TasksLikeReminderModel } from "./reminder-tasks-like";
 import { Symbol, Tokens, splitBySymbol } from "./splitter";
 
-function removeTags(text: string): string {
-  // Obsidian tags may contain any letters and digits (including non-ASCII
-  // characters), plus "-", "_" and "/" for nested tags.
-  return text.replace(/#[\p{L}\p{N}\p{M}_/-]+/gu, "").trim();
-}
-export class TasksPluginReminderModel implements ReminderModel {
+export class TasksPluginReminderModel implements TasksLikeReminderModel {
   private static readonly dateFormat = "YYYY-MM-DD";
   // The Tasks plugin itself only supports a date-only due date (📅 is
   // documented/parsed as `YYYY-MM-DD`). This plugin extends the due-date
@@ -250,7 +242,7 @@ export class TasksPluginReminderModel implements ReminderModel {
   }
 }
 
-export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginReminderModel> {
+export class TasksPluginFormat extends TasksLikeReminderFormat<TasksPluginReminderModel> {
   public static readonly instance = new TasksPluginFormat();
 
   parseReminder(todo: Todo): TasksPluginReminderModel | null {
@@ -278,73 +270,8 @@ export class TasksPluginFormat extends TodoBasedReminderFormat<TasksPluginRemind
     );
   }
 
-  override modifyReminder(
-    doc: MarkdownDocument,
-    todo: Todo,
-    parsed: TasksPluginReminderModel,
-    edit: ReminderEdit,
-  ): boolean {
-    if (!super.modifyReminder(doc, todo, parsed, edit)) {
-      return false;
-    }
-    if (edit.checked !== undefined) {
-      if (edit.checked) {
-        const recurrence = parsed.getRecurrence();
-        if (recurrence !== null) {
-          const nextReminderTodo = todo.clone()!;
-          const nextReminder = parsed.clone();
-          const dueDate = parsed.getDueDate();
-          if (dueDate == null) {
-            return false;
-          }
-
-          const now = this.config.getParameter(ReminderFormatParameterKey.now);
-          if (this.useCustomEmoji()) {
-            const time = parsed.getTime();
-            if (time == null) {
-              return false;
-            }
-            const nextTime: Date | undefined = nextOccurrence(
-              recurrence,
-              time.moment(),
-              now,
-            );
-            const nextDueDate: Date | undefined = nextOccurrence(
-              recurrence,
-              dueDate.moment(),
-              now,
-            );
-            if (nextTime == null || nextDueDate == null) {
-              return false;
-            }
-            nextReminder.setTime(new DateTime(moment(nextTime), true));
-            nextReminder.setDueDate(
-              new DateTime(moment(nextDueDate), dueDate.hasTimePart),
-            );
-          } else {
-            const next: Date | undefined = nextOccurrence(
-              recurrence,
-              dueDate.moment(),
-              now,
-            );
-            if (next == null) {
-              return false;
-            }
-            const nextDueDate = new DateTime(moment(next), dueDate.hasTimePart);
-            nextReminder.setTime(nextDueDate);
-          }
-          nextReminderTodo.body = nextReminder.toMarkdown();
-          nextReminderTodo.setChecked(false);
-          doc.insertTodo(todo.lineIndex, nextReminderTodo);
-        }
-        parsed.setDoneDate(
-          this.config.getParameter(ReminderFormatParameterKey.now),
-        );
-      } else {
-        parsed.setDoneDate(undefined);
-      }
-    }
-    return true;
+  protected override usesSeparateReminderDate(): boolean {
+    return this.useCustomEmoji();
   }
 
   newReminder(

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -2,6 +2,7 @@ import {
   ReminderFormatType,
   ReminderFormatTypes,
   changeReminderFormat,
+  dataviewReminderFormat,
   kanbanPluginReminderFormat,
   reminderPluginReminderFormat,
   setReminderFormatConfig,
@@ -47,6 +48,7 @@ export class Settings {
   excludedPaths: SettingModel<string, Array<string>>;
   useCustomEmojiForTasksPlugin: SettingModel<boolean, boolean>;
   removeTagsForTasksPlugin: SettingModel<boolean, boolean>;
+  dataviewReminderFieldName: SettingModel<string, string>;
   linkDatesToDailyNotes: SettingModel<boolean, boolean>;
   yearMonthDisplayFormat: SettingModel<string, string>;
   monthDayDisplayFormat: SettingModel<string, string>;
@@ -301,6 +303,23 @@ export class Settings {
       })
       .build(new RawSerde());
 
+    this.dataviewReminderFieldName = this.settings
+      .newSettingBuilder()
+      .key("dataviewReminderFieldName")
+      .name("Reminder field name")
+      .desc(
+        "The inline field (e.g. [reminder:: 2021-09-08]) read as the reminder date. On a line that also has a due field, this field takes precedence.",
+      )
+      .tag(TAG_RESCAN)
+      .text("reminder")
+      .placeHolder("reminder")
+      .onAnyValueChanged((context) => {
+        context.setEnabled(
+          reminderFormatSettings.enableDataviewReminderFormat.value,
+        );
+      })
+      .build(new RawSerde());
+
     this.yearMonthDisplayFormat = this.settings
       .newSettingBuilder()
       .key("yearMonthDisplayFormat")
@@ -399,6 +418,12 @@ export class Settings {
         this.removeTagsForTasksPlugin,
       );
     this.settings
+      .newGroup("Reminder Format - Dataview")
+      .addSettings(
+        reminderFormatSettings.enableDataviewReminderFormat,
+        this.dataviewReminderFieldName,
+      );
+    this.settings
       .newGroup("Reminder Format - Kanban Plugin")
       .addSettings(reminderFormatSettings.enableKanbanPluginReminderFormat);
     this.settings
@@ -433,6 +458,10 @@ export class Settings {
       ReminderFormatParameterKey.removeTagsForTasksPlugin,
       this.removeTagsForTasksPlugin,
     );
+    config.setParameter(
+      ReminderFormatParameterKey.dataviewReminderFieldName,
+      this.dataviewReminderFieldName,
+    );
     setReminderFormatConfig(config);
   }
 
@@ -448,6 +477,7 @@ class ReminderFormatSettings {
   enableReminderPluginReminderFormat: SettingModel<boolean, boolean>;
   enableTasksPluginReminderFormat: SettingModel<boolean, boolean>;
   enableKanbanPluginReminderFormat: SettingModel<boolean, boolean>;
+  enableDataviewReminderFormat: SettingModel<boolean, boolean>;
 
   constructor(private settings: SettingTabModel) {
     this.enableReminderPluginReminderFormat =
@@ -457,6 +487,9 @@ class ReminderFormatSettings {
     );
     this.enableKanbanPluginReminderFormat = this.createUseReminderFormatSetting(
       kanbanPluginReminderFormat,
+    );
+    this.enableDataviewReminderFormat = this.createUseReminderFormatSetting(
+      dataviewReminderFormat,
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #147 (5 supporting comments) and #221: users writing task metadata as Dataview inline fields — including everyone using the **Tasks plugin's "Dataview" task format** — got no reminders, because only the emoji syntax (`📅 2025-05-17`) was understood.

This adds an independent **Dataview format** that parses inline fields on checkbox lines:

```
- [ ] Buy milk [due:: 2025-05-17]
- [ ] Buy milk (due:: 2025-05-17T09:00)
- [ ] Buy milk [due:: 2025-05-17] [reminder:: 2025-05-16T21:00]
```

Neither the Dataview plugin nor the Tasks plugin needs to be installed — this is purely a text syntax, with no Dataview API dependency (future-proof against the Dataview→Datacore transition).

## Behavior

- **Field vocabulary** follows the Tasks plugin's dataview mode: `due`, `completion` (written on done), `repeat` (next occurrence inserted above on done, sharing the exact recurrence code path with the emoji format), `scheduled`/`start` (recognized and stripped from titles).
- **Per-line reminder field** (name configurable, default `reminder`) takes precedence over `due` when present. Unlike the emoji format's global "Distinguish between reminder date and due date" toggle, no mode switch is needed — field names are explicit.
- **Strict parsing only** (`YYYY-MM-DDTHH:mm`, `YYYY-MM-DD HH:mm`, `YYYY-MM-DD`): unparsable values are ignored instead of being registered at a silently wrong time (the #108 lesson). Write-back preserves the original bracket/paren style byte-for-byte and emits time-bearing values in the Dataview-parsable `T`-separated shape.
- Editor pill decoration covers exactly the matched field text (spans in original-text coordinates), which also satisfies #221's "different typography" ask.

## Implementation

- New `inline-field.ts` tokenizer (+27 tests).
- Recurrence-on-done logic extracted **verbatim** from the emoji Tasks format into a shared `TasksLikeReminderFormat` base (`reminder-tasks-like.ts`); the only per-format divergence is a `usesSeparateReminderDate()` hook. `reminder-tasks-plugin.test.ts` is byte-identical and passing — the refactor's safety net.
- New `reminder-dataview.ts` format (+28 tests) registered as `DataviewReminderFormat`; settings auto-generate the enable toggle and Primary-format dropdown entry.
- New settings group "Reminder Format - Dataview" (enable toggle + reminder field name), deliberately independent of the Tasks plugin settings group.
- Docs: new `guide/interop-dataview.md` page, pointer from `interop-tasks.md`, settings reference entries.

Design document: `design/dataview-format.md` (kept locally; summarizes syntax, sharing boundary, and deferred extensions — multi-field sources #113, preserve-due-on-snooze #67).

## Testing

- `mise run pre-commit` clean; jest 15 suites / 199 tests passing (was 171; +55 new, emoji-format tests unchanged).
- Production build succeeds.
- Manual verification in a test vault to follow; results will be posted as a comment.

Closes #147
Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)