### PR TITLE
Organize the settings screen into five tabs

### DIFF
--- a/docs/src/guide/set-reminders.md
+++ b/docs/src/guide/set-reminders.md
@@ -51,7 +51,7 @@ See following settings.
 
 - [Date Format](/setting/#date-format)
 - [Date and Time Format](/setting/#date-and-time-format)
-- For display formats (how dates/times are shown in the UI), see [Date/Time Display Format](/setting/#date-time-display-format)
+- For display formats (how dates/times are shown in the UI), see the [Display](/setting/#display) settings
 
 ## Reminder date input support
 
@@ -62,7 +62,7 @@ Also, you can set reminder time with time picker.
 ::: tip
 
 - You can change the format by [primary reminder format](/setting/#primary-reminder-format) setting.
-- Time step in time picker is set by [Reminder Time Step](/setting/#reminder-time-step) setting.
+- Time step in time picker is set by [Reminder time step (minutes)](/setting/#reminder-time-step-minutes) setting.
 
 :::
 

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -4,7 +4,9 @@ sidebar: auto
 
 # Config
 
-## Reminder Time
+## Notifications
+
+### Reminder time
 
 Time when a reminder with no time part will show.
 
@@ -12,30 +14,99 @@ Time when a reminder with no time part will show.
 - Format: `HH:mm` (HH: hour, mm: minute)
 - Default: `09:00`
 
-## Reminder Time Step
+### Reminder time step (minutes)
 
 Step of time for reminder time.
 
 - Type: `number`
 - Default: `15`
 
-## Date format
+### Remind me later
 
-Format for reminder date without time.
-
-- Type: `string`
-- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
-- Default: `YYYY-MM-DD`
-
-## Date and time format
-
-Format for reminder date time.
+You can change option which will be shown when you click `Remind Me Later` button in the [notification](/guide/notification.html).
 
 - Type: `string`
-- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
-- Default: `YYYY-MM-DD HH:mm`
+- Format: Line-separated following options
+  - In N minutes/hours/days/weeks/months/years
+  - Next Sunday/Monday/Tuesday/Wednesday/Thursday/Friday/Saturday/day/week/month/year
+  - Tomorrow
 
-## Calendar popup trigger
+### Enable reminder notifications
+
+Show reminder popups and system notifications when a reminder is due.
+
+- Type: `boolean`
+- Values:
+  - ON: Reminder popups/system notifications are shown when due (default)
+  - OFF: Reminder popups/system notifications are suppressed. The [reminder list view](/guide/list-reminders.html) keeps updating, and expired reminders still move to the [Overdue section](/guide/list-reminders.html#overdue-reminders).
+- Default: ON
+
+### Reminder popup style
+
+Choose how the [builtin notification popup](/guide/notification.html#builtin-notification-modal) is presented.
+
+- Type: `select`
+- Values:
+  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing (default). Multiple toasts stack when several reminders fire close together. Keyboard shortcuts apply only to the most recently shown toast; older toasts are mouse/touch only. Toasts appear immediately, even while you're typing — see [Edit Detection Time](#edit-detection-time).
+  - Modal (center dialog): a dialog in the center of the window that takes focus.
+- Default: Toast (corner card)
+
+### Open note on reminder click
+
+Open the note directly instead of showing the reminder popup when you click a reminder.
+
+- Type: `boolean`
+- Values:
+  - ON: Clicking a reminder in the [reminder list](/guide/list-reminders.html), or clicking a system notification, opens the note directly.
+  - OFF: Clicking an overdue/muted reminder shows the [reminder popup](/guide/notification.html) again. Clicking a system notification shows the builtin notification in Obsidian.
+- Default: OFF
+
+### Use system notification
+
+Use system notification instead of builtin notification.
+
+Only available on desktop OS.
+
+- Type: `boolean`
+- Values:
+  - ON: Use system notification. In mobile devices, this setting is ignored and builtin notification is used.
+  - OFF: Use builtin notification
+
+### Show popup together with system notification
+
+Show the built-in reminder popup at the same time as the system notification.
+
+Only takes effect while [Use system notification](#use-system-notification) is enabled.
+
+- Type: `boolean`
+- Values:
+  - ON: Both surfaces are shown at once. The popup handles the reminder actions (mark as done/remind me later/mute/open note); the system notification acts as an alert only, so clicking it just closes it, or opens the note when [Open note on reminder click](#open-note-on-reminder-click) is enabled.
+  - OFF: Only the system notification is shown, and it handles the reminder actions itself.
+- Default: OFF
+
+### Focus Done button on popup
+
+Automatically focus the Done button when a reminder popup opens, so pressing Enter completes the task. Off by default to prevent accidentally completing a reminder you haven't read.
+
+- Type: `boolean`
+- Values:
+  - ON: The Done button is focused when the popup opens; pressing Enter immediately marks the reminder as done.
+  - OFF: Nothing is focused when the popup opens, so a stray Enter/Space keypress does nothing (default). Use the [keyboard shortcuts](/guide/notification.html#builtin-notification-modal) to operate the popup quickly instead.
+- Default: OFF
+
+### Show overdue count in status bar
+
+Show the number of overdue reminders in the status bar (e.g. `⏰ 3`). Muted overdue reminders are still counted. Click the status bar item to open the [reminder list view](/guide/list-reminders.html).
+
+- Type: `boolean`
+- Values:
+  - ON: The status bar item is shown whenever there is at least one overdue reminder (default)
+  - OFF: The status bar item is never shown
+- Default: ON
+
+## Editor
+
+### Calendar popup trigger
 
 Trigger to show calendar popup.
 
@@ -43,7 +114,7 @@ Trigger to show calendar popup.
 - Format: Any string. If you make this setting empty string, calendar popup will be disabled.
 - Default: `(@`
 
-## Convert non-task lines when inserting a reminder
+### Convert non-task lines when inserting a reminder
 
 When inserting a reminder from the [calendar popup](/guide/set-reminders.html#reminder-date-input-support) on a line that is not a task, the line is automatically converted into a task list item (`- [ ] `). Bullets (`- `, `* `, `+ `) get a checkbox inserted after the marker, and plain text or empty lines get `- [ ] ` prepended. Headings, numbered lists, tables, and code fences are not converted; a notice is shown instead.
 
@@ -53,7 +124,7 @@ When inserting a reminder from the [calendar popup](/guide/set-reminders.html#re
   - OFF: A notice is always shown for non-task lines
 - Default: ON
 
-## Primary reminder format
+### Primary reminder format
 
 Reminder format for generated reminder by calendar popup.
 
@@ -64,7 +135,7 @@ Reminder format for generated reminder by calendar popup.
   - [Kanban plugin format](/guide/interop-kanban.html)
   - [Dataview format](/guide/interop-dataview.html)
 
-## Show reminder pills in editor
+### Show reminder pills in editor
 
 Render each reminder's time as a clickable pill (⏰) in [Live Preview](https://help.obsidian.md/Editing+and+formatting/Editing+modes). Clicking a pill opens the date/time chooser to change it, only available on desktop.
 
@@ -74,27 +145,25 @@ Render each reminder's time as a clickable pill (⏰) in [Live Preview](https://
   - OFF: Reminder times are shown as raw text
 - Default: ON
 
-## Excluded files/folders
+## Reminder formats
 
-Reminders in these files/folders are ignored when scanning the vault, and any reminders already found in them are removed.
+### Date format
+
+Format for reminder date without time.
 
 - Type: `string`
-- Format: Line-separated list of vault-relative paths. One path per line.
-  - An entry matches the file/folder itself and everything under it, on a path-segment boundary. For example, `Templates` excludes `Templates/Daily.md`, but not `Templates2/Daily.md`.
-  - Leading/trailing slashes are ignored.
-  - Matching is case-sensitive.
-- Default: (empty)
+- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
+- Default: `YYYY-MM-DD`
 
-Example
+### Date and time format
 
-```
-Templates
-Archive/2020
-```
+Format for reminder date time.
 
-Takes effect immediately; you don't need to restart Obsidian.
+- Type: `string`
+- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
+- Default: `YYYY-MM-DD HH:mm`
 
-## Link dates to daily notes
+### Link dates to daily notes
 
 You can link dates to daily notes with this option.
 
@@ -116,80 +185,7 @@ Example (ON)
 - [ ] Task ([[@2021-09-15]] 10:00)
 ```
 
-## Remind me later
-
-You can change option which will be shown when you click `Remind Me Later` button in the [notification](/guide/notification.html).
-
-- Type: `string`
-- Format: Line-separated following options
-  - In N minutes/hours/days/weeks/months/years
-  - Next Sunday/Monday/Tuesday/Wednesday/Thursday/Friday/Saturday/day/week/month/year
-  - Tomorrow
-
-## Enable reminder notifications
-
-Show reminder popups and system notifications when a reminder is due.
-
-- Type: `boolean`
-- Values:
-  - ON: Reminder popups/system notifications are shown when due (default)
-  - OFF: Reminder popups/system notifications are suppressed. The [reminder list view](/guide/list-reminders.html) keeps updating, and expired reminders still move to the [Overdue section](/guide/list-reminders.html#overdue-reminders).
-- Default: ON
-
-## Reminder popup style
-
-Choose how the [builtin notification popup](/guide/notification.html#builtin-notification-modal) is presented.
-
-- Type: `select`
-- Values:
-  - Toast (corner card): a card stacked in the bottom-right corner of the window that does not take focus or interrupt what you're doing (default). Multiple toasts stack when several reminders fire close together. Keyboard shortcuts apply only to the most recently shown toast; older toasts are mouse/touch only. Toasts appear immediately, even while you're typing — see [Edit Detection Time](#edit-detection-time).
-  - Modal (center dialog): a dialog in the center of the window that takes focus.
-- Default: Toast (corner card)
-
-## Open note on reminder click
-
-Open the note directly instead of showing the reminder popup when you click a reminder.
-
-- Type: `boolean`
-- Values:
-  - ON: Clicking a reminder in the [reminder list](/guide/list-reminders.html), or clicking a system notification, opens the note directly.
-  - OFF: Clicking an overdue/muted reminder shows the [reminder popup](/guide/notification.html) again. Clicking a system notification shows the builtin notification in Obsidian.
-- Default: OFF
-
-## Use system notification
-
-Use system notification instead of builtin notification.
-
-Only available on desktop OS.
-
-- Type: `boolean`
-- Values:
-  - ON: Use system notification. In mobile devices, this setting is ignored and builtin notification is used.
-  - OFF: Use builtin notification
-
-## Show popup together with system notification
-
-Show the built-in reminder popup at the same time as the system notification.
-
-Only takes effect while [Use system notification](#use-system-notification) is enabled.
-
-- Type: `boolean`
-- Values:
-  - ON: Both surfaces are shown at once. The popup handles the reminder actions (mark as done/remind me later/mute/open note); the system notification acts as an alert only, so clicking it just closes it, or opens the note when [Open note on reminder click](#open-note-on-reminder-click) is enabled.
-  - OFF: Only the system notification is shown, and it handles the reminder actions itself.
-- Default: OFF
-
-## Focus Done button on popup
-
-Automatically focus the Done button when a reminder popup opens, so pressing Enter completes the task. Off by default to prevent accidentally completing a reminder you haven't read.
-
-- Type: `boolean`
-- Values:
-  - ON: The Done button is focused when the popup opens; pressing Enter immediately marks the reminder as done.
-  - OFF: Nothing is focused when the popup opens, so a stray Enter/Space keypress does nothing (default). Use the [keyboard shortcuts](/guide/notification.html#builtin-notification-modal) to operate the popup quickly instead.
-- Default: OFF
-
-## Enable Tasks plugin format
+### Enable Tasks plugin format
 
 Enable support for [Tasks Plugin](https://github.com/schemar/obsidian-tasks)
 
@@ -198,7 +194,7 @@ Enable support for [Tasks Plugin](https://github.com/schemar/obsidian-tasks)
   - ON: Enable Tasks plugin format
   - OFF: Disable Tasks plugin format (default)
 
-## Distinguish between reminder date and due date
+### Distinguish between reminder date and due date
 
 Use custom emoji ⏰ instead of 📅 and distinguish between reminder date/time and Tasks Plugin's due date.
 
@@ -207,7 +203,7 @@ Use custom emoji ⏰ instead of 📅 and distinguish between reminder date/time 
   - ON: Reminder is set using ⏰
   - OFF: Reminder is set using 📅 (default)
 
-## Remove tags from reminder title
+### Remove tags from reminder title
 
 If checked, the tags (#xxx) will be removed from the reminder title.
 This setting affects only tasks plugin format.
@@ -217,7 +213,7 @@ This setting affects only tasks plugin format.
   - ON: Tags are removed
   - OFF: Tags are not removed (default)
 
-## Enable Dataview format
+### Enable Dataview format
 
 Enable support for the [Dataview format](/guide/interop-dataview.html)
 (`[due:: 2021-09-08]`), including the Tasks plugin's own Dataview task
@@ -228,7 +224,7 @@ format.
   - ON: Enable Dataview format
   - OFF: Disable Dataview format (default)
 
-## Reminder field name
+### Reminder field name
 
 The name of the inline field (e.g. `[reminder:: 2021-09-08]`) read as the
 reminder date. On a line that also has a `due` field, this field takes
@@ -238,7 +234,7 @@ date](/guide/interop-dataview.html#distinguish-due-date-and-reminder-date).
 - Type: `string`
 - Default: `reminder`
 
-## Enable Kanban plugin format
+### Enable Kanban plugin format
 
 Enable support for [Kanban Plugin](https://github.com/mgmeyers/obsidian-kanban)
 
@@ -247,72 +243,42 @@ Enable support for [Kanban Plugin](https://github.com/mgmeyers/obsidian-kanban)
   - ON: Enable Kanban plugin format
   - OFF: Disable Kanban plugin format (default)
 
-## Edit Detection Time
-
-In order not to interfere with normal Markdown editing, the Reminder Plugin will not show reminders while the user is editing a file.
-The value of this setting is the minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable.
-
-This only applies to the [Modal popup style](#reminder-popup-style), which takes focus and would otherwise interrupt typing. The Toast popup style is not focus-stealing, so toasts appear immediately regardless of this setting.
-
-- Type: `number`
-- Value: The value of this setting is the minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable. If this value is set to 0, the reminder will be displayed even if the file is being edited.
-- Default: `10`
-
-## Week start
-
-Select which day is considered the first day of the week. This affects the Calendar popup.
-
-- Type: `select`
-- Values: Localized weekday names Sunday, Monday, ... Saturday
-- Default: `Sunday`
-
-Notes:
-
-- Changing this updates the calendar grid to start on your chosen day.
-- Weekend highlighting adapts automatically based on this setting.
-
-## Reminder check interval
-
-Interval(in seconds) to periodically check whether or not you should be notified of reminders.  
-You will need to restart Obsidian for this setting to take effect.
-
-- Type: `number`
-
-## Date/Time Display Format
+## Display
 
 You can customize how dates and times are displayed in the Reminder List and related UI. This affects:
 
 - Group headers such as Year/Month, Today, Tomorrow, and weekday lines
 - Time display for each reminder item
 
-Four independent Moment-style display formats are available:
+Four independent Moment-style display formats are available, plus the first day of the week used by the calendar popup.
 
-- Year & Month Format
+### Year & month format
 
-  - Type: `string`
-  - Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
-  - Default: `YYYY, MMMM`
-  - Example: `2025, August`
+- Type: `string`
+- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
+- Default: `YYYY, MMMM`
+- Example: `2025, August`
 
-- Month & Day Format
+### Month & day format
 
-  - Type: `string`
-  - Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
-  - Default: `MM/DD`
-  - Example: `08/03`
+- Type: `string`
+- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
+- Default: `MM/DD`
+- Example: `08/03`
 
-- Short Date with Weekday Format
+### Short date with weekday format
 
-  - Type: `string`
-  - Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
-  - Default: `M/DD (ddd)`
-  - Example: `8/03 (Sun)`
+- Type: `string`
+- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
+- Default: `M/DD (ddd)`
+- Example: `8/03 (Sun)`
 
-- Time Format
-  - Type: `string`
-  - Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
-  - Default: `HH:mm`
-  - Example: `09:30`
+### Time format
+
+- Type: `string`
+- Format: [momentjs format](https://momentjs.com/docs/#/displaying/format/)
+- Default: `HH:mm`
+- Example: `09:30`
 
 ### Presets
 
@@ -328,14 +294,56 @@ You can quickly apply a preset via the command palette:
 
 Running the command opens a chooser with live examples. Selecting a preset immediately saves settings and refreshes the Reminder List.
 
+### Week start
+
+Select which day is considered the first day of the week. This affects the Calendar popup.
+
+- Type: `select`
+- Values: Localized weekday names Sunday, Monday, ... Saturday
+- Default: `Sunday`
+
+Notes:
+
+- Changing this updates the calendar grid to start on your chosen day.
+- Weekend highlighting adapts automatically based on this setting.
+
+## Advanced
+
+### Excluded files/folders
+
+Reminders in these files/folders are ignored when scanning the vault, and any reminders already found in them are removed.
+
+- Type: `string`
+- Format: Line-separated list of vault-relative paths. One path per line.
+  - An entry matches the file/folder itself and everything under it, on a path-segment boundary. For example, `Templates` excludes `Templates/Daily.md`, but not `Templates2/Daily.md`.
+  - Leading/trailing slashes are ignored.
+  - Matching is case-sensitive.
+- Default: (empty)
+
+Example
+
+```
+Templates
+Archive/2020
+```
+
+Takes effect immediately; you don't need to restart Obsidian.
+
+### Edit detection time
+
+In order not to interfere with normal Markdown editing, the Reminder Plugin will not show reminders while the user is editing a file.
+The value of this setting is the minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable.
+
+This only applies to the [Modal popup style](#reminder-popup-style), which takes focus and would otherwise interrupt typing. The Toast popup style is not focus-stealing, so toasts appear immediately regardless of this setting.
+
+- Type: `number`
+- Value: The value of this setting is the minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable. If this value is set to 0, the reminder will be displayed even if the file is being edited.
+- Default: `10`
+
+### Reminder check interval
+
+Interval(in seconds) to periodically check whether or not you should be notified of reminders.  
+You will need to restart Obsidian for this setting to take effect.
+
+- Type: `number`
 - Default: `5`
-
-## Show overdue count in status bar
-
-Show the number of overdue reminders in the status bar (e.g. `⏰ 3`). Muted overdue reminders are still counted. Click the status bar item to open the [reminder list view](/guide/list-reminders.html).
-
-- Type: `boolean`
-- Values:
-  - ON: The status bar item is shown whenever there is at least one overdue reminder (default)
-  - OFF: The status bar item is never shown
-- Default: ON

--- a/src/plugin/settings/helper.ts
+++ b/src/plugin/settings/helper.ts
@@ -3,6 +3,7 @@ import type { ReadOnlyReference } from "model/ref";
 import { Later, Time, parseLaters } from "model/time";
 import { AbstractTextComponent, Setting } from "obsidian";
 import { ReminderFormatType, ReminderFormatTypes } from "model/format";
+import "./settings-tab.css";
 
 class SettingRegistry {
   private settingContexts: Array<SettingContext> = [];
@@ -33,24 +34,20 @@ class SettingContext {
 
   constructor(private _settingRegistry: SettingRegistry) {}
 
-  init(
-    settingModel: SettingModelBase,
-    setting: Setting,
-    containerEl: HTMLElement,
-  ) {
+  init(settingModel: SettingModelBase, setting: Setting) {
     this.settingModel = settingModel;
     this._setting = setting;
 
-    this.validationEl = containerEl.createDiv("validation", (el) => {
+    // Appended to the setting's description element so validation/info lines
+    // render inside the setting item, under the description text.
+    this.validationEl = setting.descEl.createDiv("validation", (el) => {
       el.style.color = "var(--text-error)";
-      el.style.marginBottom = "1rem";
-      el.style.fontSize = "14px";
+      el.style.marginTop = "0.25rem";
       el.style.display = "none";
     });
-    this.infoEl = containerEl.createDiv("info", (el) => {
+    this.infoEl = setting.descEl.createDiv("info", (el) => {
       el.style.color = "var(--text-faint)";
-      el.style.marginBottom = "1rem";
-      el.style.fontSize = "14px";
+      el.style.marginTop = "0.25rem";
       el.style.display = "none";
     });
   }
@@ -89,6 +86,9 @@ class SettingContext {
   }
 
   update() {
+    if (!this.isInitialized()) {
+      return;
+    }
     if (!this.anyValueChanged) {
       return;
     }
@@ -97,6 +97,7 @@ class SettingContext {
 
   setEnabled(enable: boolean) {
     this.setting!.setDisabled(!enable);
+    this.setting!.settingEl.toggleClass("reminder-setting-disabled", !enable);
   }
 
   findContextByKey(key: string) {
@@ -422,7 +423,7 @@ class SettingModelImpl<R, E> implements SettingModel<R, E> {
     const setting = new Setting(containerEl)
       .setName(this.context.name ?? "")
       .setDesc(this.context.desc ?? "");
-    this.context.init(this, setting, containerEl);
+    this.context.init(this, setting);
     this.settingInitializer({
       setting,
       rawValue: this.rawValue,
@@ -462,42 +463,97 @@ class SettingModelImpl<R, E> implements SettingModel<R, E> {
 
 export class SettingGroup {
   public settings: Array<SettingModelBase> = [];
-  constructor(public name: string) {}
+  constructor(public name?: string) {}
 
   addSettings(...settingModels: Array<SettingModelBase>) {
     this.settings.push(...settingModels);
   }
 }
 
+export class SettingPage {
+  public groups: Array<SettingGroup> = [];
+  constructor(public name: string) {}
+
+  newGroup(name?: string): SettingGroup {
+    const group = new SettingGroup(name);
+    this.groups.push(group);
+    return group;
+  }
+}
+
 export class SettingTabModel {
-  private groups: Array<SettingGroup> = [];
+  private pages: Array<SettingPage> = [];
   private registry: SettingRegistry = new SettingRegistry();
+  // Session-only: which tab is shown. Intentionally not persisted to
+  // data.json (resets to the first tab on every Obsidian restart).
+  private activeTabIndex = 0;
 
   newSettingBuilder(): SettingModelBuilder {
     return new SettingModelBuilder(this.registry);
   }
 
-  newGroup(name: string): SettingGroup {
-    const group = new SettingGroup(name);
-    this.groups.push(group);
-    return group;
+  newPage(name: string): SettingPage {
+    const page = new SettingPage(name);
+    this.pages.push(page);
+    return page;
   }
 
   displayOn(el: HTMLElement) {
     el.empty();
-    this.groups.forEach((group) => {
-      el.createEl("h3", { text: group.name });
+
+    const tabBarEl = el.createDiv("reminder-settings-tab-bar");
+    tabBarEl.setAttribute("role", "tablist");
+    const tabButtons: Array<HTMLElement> = this.pages.map((page, index) => {
+      const tabEl = tabBarEl.createEl("button", {
+        cls: "reminder-settings-tab",
+        text: page.name,
+      });
+      tabEl.setAttribute("role", "tab");
+      tabEl.setAttribute("type", "button");
+      tabEl.addEventListener("click", () => {
+        this.activeTabIndex = index;
+        this.updateTabButtons(tabButtons);
+        this.renderActivePage(contentEl);
+      });
+      return tabEl;
+    });
+    this.updateTabButtons(tabButtons);
+
+    const contentEl = el.createDiv("reminder-settings-tab-content");
+    this.renderActivePage(contentEl);
+  }
+
+  private updateTabButtons(tabButtons: Array<HTMLElement>) {
+    tabButtons.forEach((tabEl, index) => {
+      const active = index === this.activeTabIndex;
+      tabEl.toggleClass("is-active", active);
+      tabEl.setAttribute("aria-selected", active ? "true" : "false");
+    });
+  }
+
+  private renderActivePage(contentEl: HTMLElement) {
+    contentEl.empty();
+    const activePage = this.pages[this.activeTabIndex];
+    if (activePage === undefined) {
+      return;
+    }
+    activePage.groups.forEach((group) => {
+      if (group.name !== undefined) {
+        new Setting(contentEl).setName(group.name).setHeading();
+      }
       group.settings.forEach((settings) => {
-        settings.createSetting(el);
+        settings.createSetting(contentEl);
       });
     });
     this.registry.forEach((context) => context.update());
   }
 
   public forEach(consumer: (setting: SettingModelBase) => void) {
-    this.groups.forEach((group) => {
-      group.settings.forEach((setting) => {
-        consumer(setting);
+    this.pages.forEach((page) => {
+      page.groups.forEach((group) => {
+        group.settings.forEach((setting) => {
+          consumer(setting);
+        });
       });
     });
   }

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -65,7 +65,7 @@ export class Settings {
     this.reminderTime = this.settings
       .newSettingBuilder()
       .key("reminderTime")
-      .name("Reminder Time")
+      .name("Reminder time")
       .desc("Time when a reminder with no time part will show")
       .tag(TAG_RESCAN)
       .text("09:00")
@@ -75,7 +75,7 @@ export class Settings {
     this.reminderTimeStep = this.settings
       .newSettingBuilder()
       .key("reminderTimeStep")
-      .name("Reminder Time Step (minutes)")
+      .name("Reminder time step (minutes)")
       .desc("Step of time for reminder time (minutes)")
       .number(15)
       .build(new RawSerde());
@@ -189,10 +189,15 @@ export class Settings {
     this.strictDateFormat = this.settings
       .newSettingBuilder()
       .key("strictDateFormat")
-      .name("Strict Date format")
+      .name("Strict date format")
       .desc("Strictly parse the date and time")
       .tag(TAG_RESCAN)
       .toggle(false)
+      .onAnyValueChanged((context) => {
+        context.setEnabled(
+          reminderFormatSettings.enableReminderPluginReminderFormat.value,
+        );
+      })
       .build(new RawSerde());
 
     this.dateTimeFormat = this.settings
@@ -337,7 +342,7 @@ export class Settings {
     this.yearMonthDisplayFormat = this.settings
       .newSettingBuilder()
       .key("yearMonthDisplayFormat")
-      .name("Year & Month Format")
+      .name("Year & month format")
       .desc(
         "Moment style year and month format:\nhttps://momentjs.com/docs/#/displaying/format/",
       )
@@ -347,7 +352,7 @@ export class Settings {
     this.monthDayDisplayFormat = this.settings
       .newSettingBuilder()
       .key("monthDayDisplayFormat")
-      .name("Month & Day Format")
+      .name("Month & day format")
       .desc(
         "Moment style month and day format:\nhttps://momentjs.com/docs/#/displaying/format/",
       )
@@ -357,7 +362,7 @@ export class Settings {
     this.shortDateWithWeekdayDisplayFormat = this.settings
       .newSettingBuilder()
       .key("shortDateWithWeekdayDisplayFormat")
-      .name("Short Date with Weekday Format")
+      .name("Short date with weekday format")
       .desc(
         "Moment style short date with weekday format:\nhttps://momentjs.com/docs/#/displaying/format/",
       )
@@ -367,7 +372,7 @@ export class Settings {
     this.timeDisplayFormat = this.settings
       .newSettingBuilder()
       .key("timeDisplayFormat")
-      .name("Time Format")
+      .name("Time format")
       .desc(
         "Moment style time format:\nhttps://momentjs.com/docs/#/displaying/format/",
       )
@@ -378,7 +383,7 @@ export class Settings {
     this.editDetectionSec = this.settings
       .newSettingBuilder()
       .key("editDetectionSec")
-      .name("Edit Detection Time")
+      .name("Edit detection time")
       .desc(
         "The minimum amount of time (in seconds) after a key is typed that it will be identified as notifiable. Only applies to the Modal popup style; Toast reminders are shown immediately even while typing.",
       )
@@ -405,7 +410,8 @@ export class Settings {
       .build(new RawSerde());
 
     this.settings
-      .newGroup("Notification Settings")
+      .newPage("Notifications")
+      .newGroup()
       .addSettings(
         this.reminderTime,
         this.reminderTimeStep,
@@ -419,16 +425,17 @@ export class Settings {
         this.showOverdueCountInStatusBar,
       );
     this.settings
-      .newGroup("Editor")
+      .newPage("Editor")
+      .newGroup()
       .addSettings(
         this.autoCompleteTrigger,
         this.convertNonTaskLines,
         this.primaryFormat,
         this.editorReminderDisplay,
       );
-    this.settings.newGroup("File Scanning").addSettings(this.excludedPaths);
-    this.settings
-      .newGroup("Reminder Format - Reminder Plugin")
+    const reminderFormatsPage = this.settings.newPage("Reminder formats");
+    reminderFormatsPage
+      .newGroup("Reminder plugin format")
       .addSettings(
         reminderFormatSettings.enableReminderPluginReminderFormat,
         this.dateFormat,
@@ -436,36 +443,39 @@ export class Settings {
         this.strictDateFormat,
         this.linkDatesToDailyNotes,
       );
-    this.settings
-      .newGroup("Reminder Format - Tasks Plugin")
+    reminderFormatsPage
+      .newGroup("Tasks plugin format")
       .addSettings(
         reminderFormatSettings.enableTasksPluginReminderFormat,
         this.useCustomEmojiForTasksPlugin,
         this.removeTagsForTasksPlugin,
       );
-    this.settings
-      .newGroup("Reminder Format - Dataview")
+    reminderFormatsPage
+      .newGroup("Dataview format")
       .addSettings(
         reminderFormatSettings.enableDataviewReminderFormat,
         this.dataviewReminderFieldName,
       );
-    this.settings
-      .newGroup("Reminder Format - Kanban Plugin")
+    reminderFormatsPage
+      .newGroup("Kanban plugin format")
       .addSettings(reminderFormatSettings.enableKanbanPluginReminderFormat);
     this.settings
-      .newGroup("Date/Time Display Format")
+      .newPage("Display")
+      .newGroup()
       .addSettings(
         this.yearMonthDisplayFormat,
         this.monthDayDisplayFormat,
         this.shortDateWithWeekdayDisplayFormat,
         this.timeDisplayFormat,
+        this.weekStart,
       );
     this.settings
-      .newGroup("Advanced")
+      .newPage("Advanced")
+      .newGroup()
       .addSettings(
+        this.excludedPaths,
         this.editDetectionSec,
         this.reminderCheckIntervalSec,
-        this.weekStart,
       );
 
     const config = new ReminderFormatConfig();
@@ -525,7 +535,7 @@ class ReminderFormatSettings {
       .newSettingBuilder()
       .key(key)
       .name(`Enable ${format.description}`)
-      .desc(`Enable ${format.description}`)
+      .desc("Recognize reminders written in this format.")
       .tag(TAG_RESCAN)
       .toggle(format.defaultEnabled)
       .onAnyValueChanged((context) => {

--- a/src/plugin/settings/settings-tab.css
+++ b/src/plugin/settings/settings-tab.css
@@ -1,0 +1,25 @@
+.reminder-settings-tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--background-modifier-border);
+  margin-bottom: 1rem;
+}
+
+.reminder-settings-tab {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+}
+
+.reminder-settings-tab.is-active {
+  color: var(--text-normal);
+  border-bottom: 2px solid var(--interactive-accent);
+}
+
+.reminder-setting-disabled {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary

The settings screen had grown to 9 groups / 33 settings on a single scroll, with raw `h3` headings that were easy to miss, making it hard for new users to find anything. This PR reorganizes it into five horizontal tabs:

| Tab | Contents |
| --- | --- |
| Notifications | Reminder time, popup style, system notification, etc. (10 settings) |
| Editor | Calendar popup trigger, reminder pills, etc. (4 settings) |
| Reminder formats | The four format groups merged, with per-format section headings (11 settings) |
| Display | Date/time display formats + week start (5 settings) |
| Advanced | Excluded paths, edit detection, check interval (3 settings) |

Design notes: horizontal tabs (the settings modal already has a vertical nav; the tab bar wraps on narrow widths), selected tab remembered for the session only, no setting keys changed so there is no data migration.

## Also included

- Group headings now use `Setting.setHeading()` instead of raw `h3`, headings drop the redundant word "Settings", and setting names are renamed to sentence case, per the [official plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines).
- Validation/info lines (e.g. the dynamic `Example: ...` line under format toggles) now render inside the setting item's description element instead of flush-left at container level, where they looked like section dividers.
- Disabled setting items are dimmed (`opacity: 0.5`) so dependency-disabled settings are visually distinguishable; input components remain natively disabled and description links stay clickable.
- Fixed a pre-existing gap: "Strict date format" was the only setting in the Reminder plugin format group missing the enable/disable wiring and stayed editable while the format was disabled.
- `SettingContext.update()` now skips uninitialized contexts (settings on inactive tabs have no DOM).
- Settings documentation restructured to match the new tab layout, including two cross-reference anchors in `set-reminders.md` that the restructure would have broken.

## Verification

- `mise run main:lint:fix` — 0 errors, 0 warnings.
- `mise run main:test` — 203/203 tests passed.
- Manually verified in a test vault (Obsidian + hot-reload): tab structure and per-tab contents (all 33 settings present, headings only on the Reminder formats tab), enable/disable dependencies grey out correctly including after switching tabs back and forth, edited values survive tab switches, validation errors and format-example info lines render inside the setting item, the selected tab is remembered across settings modal reopens, the tab bar wraps on narrow windows, no console errors, and reminder parsing/list display still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)