### PR TITLE
Add fallback for Tasks plugin reminder time (⏰ → 📅 → ⏳ → 🛫)

### DIFF
--- a/docs/src/guide/interop-tasks.md
+++ b/docs/src/guide/interop-tasks.md
@@ -68,6 +68,32 @@ You can't insert any characters other than date/time between ⏰ and 📅.
 - (NG) `- [ ] Task ⏰ 2021-09-16 #Tag 📅 2021-09-17`
 :::
 
+### Fall back to due, scheduled, or start date
+
+With "Distinguish between reminder date and due date" enabled, a task
+without ⏰ is normally not treated as a reminder at all. If you enable
+[Fall back to due, scheduled, or start
+date](/setting/#fall-back-to-due-scheduled-or-start-date), the reminder
+date falls back through 📅 (due), then ⏳ (scheduled), then 🛫 (start), in
+that order, whenever ⏰ is missing.
+
+```markdown
+- [ ] Task ⏳ 2021-09-16
+```
+
+Here, the reminder fires on 2021-09-16 even though no ⏰ is present.
+
+::: tip
+When both 📅 and ⏳ are present, 📅 always wins — the fallback order
+mirrors the Tasks Plugin's own specificity (due date is more specific
+than scheduled date). To make a task remind on its scheduled date instead
+of its due date, set an explicit ⏰ equal to the scheduled date.
+:::
+
+Snoozing ("remind me later") always writes ⏰ and never overwrites
+📅/⏳/🛫, so the due/scheduled/start date on the line is preserved even
+after you snooze a fallback-triggered reminder.
+
 ## Using the Tasks plugin's Dataview task format
 
 The Tasks plugin also supports writing task metadata as Dataview inline

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -203,6 +203,18 @@ Use custom emoji ⏰ instead of 📅 and distinguish between reminder date/time 
   - ON: Reminder is set using ⏰
   - OFF: Reminder is set using 📅 (default)
 
+### Fall back to due, scheduled, or start date
+
+Only available when [Distinguish between reminder date and due
+date](#distinguish-between-reminder-date-and-due-date) is enabled. When the
+reminder date (⏰) is missing, use the due date (📅), then the scheduled
+date (⏳), then the start date (🛫), in that order.
+
+- Type: `boolean`
+- Values:
+  - ON: Fall back through 📅 → ⏳ → 🛫 when ⏰ is missing
+  - OFF: Only ⏰ is recognized as the reminder date (default)
+
 ### Remove tags from reminder title
 
 If checked, the tags (#xxx) will be removed from the reminder title.

--- a/src/model/format/reminder-base.ts
+++ b/src/model/format/reminder-base.ts
@@ -50,6 +50,11 @@ export class ReminderFormatParameterKey<T> {
     );
   static readonly removeTagsForTasksPlugin =
     new ReminderFormatParameterKey<boolean>("removeTagsForTasksPlugin", false);
+  static readonly useReminderTimeFallbackForTasksPlugin =
+    new ReminderFormatParameterKey<boolean>(
+      "useReminderTimeFallbackForTasksPlugin",
+      false,
+    );
   static readonly dataviewReminderFieldName =
     new ReminderFormatParameterKey<string>(
       "dataviewReminderFieldName",

--- a/src/model/format/reminder-dataview.test.ts
+++ b/src/model/format/reminder-dataview.test.ts
@@ -276,6 +276,38 @@ describe("DataviewReminderFormat", (): void => {
         },
       });
     });
+
+    test("recurrence with a reminder-field-only line (no due field at all) recurs correctly (guard-relocation fix)", async () => {
+      await util.testModify({
+        inputMarkdown:
+          "- [ ] Task [repeat:: every day] [reminder:: 2025-05-17T09:00]",
+        edit: { checked: true },
+        expectedMarkdown: `- [ ] Task [repeat:: every day] [reminder:: 2025-05-19T09:00]
+- [x] Task [repeat:: every day] [reminder:: 2025-05-17T09:00] [completion:: 2025-05-18]`,
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.now,
+            new DateTime(moment("2025-05-18 08:00"), true),
+          );
+        },
+      });
+    });
+
+    test("recurrence hasTimePart fix: a date-only reminder-field-only line stays date-only (no fabricated 00:00)", async () => {
+      await util.testModify({
+        inputMarkdown:
+          "- [ ] Task [repeat:: every day] [reminder:: 2025-05-17]",
+        edit: { checked: true },
+        expectedMarkdown: `- [ ] Task [repeat:: every day] [reminder:: 2025-05-19]
+- [x] Task [repeat:: every day] [reminder:: 2025-05-17] [completion:: 2025-05-18]`,
+        configFunc: (config) => {
+          config.setParameterValue(
+            ReminderFormatParameterKey.now,
+            new DateTime(moment("2025-05-18"), true),
+          );
+        },
+      });
+    });
   });
 });
 

--- a/src/model/format/reminder-tasks-like.ts
+++ b/src/model/format/reminder-tasks-like.ts
@@ -65,9 +65,6 @@ export abstract class TasksLikeReminderFormat<
           const nextReminderTodo = todo.clone()!;
           const nextReminder = parsed.clone();
           const dueDate = parsed.getDueDate();
-          if (dueDate == null) {
-            return false;
-          }
 
           const now = this.config.getParameter(ReminderFormatParameterKey.now);
           if (this.usesSeparateReminderDate(parsed)) {
@@ -80,19 +77,35 @@ export abstract class TasksLikeReminderFormat<
               time.moment(),
               now,
             );
-            const nextDueDate: Date | undefined = nextOccurrence(
-              recurrence,
-              dueDate.moment(),
-              now,
-            );
-            if (nextTime == null || nextDueDate == null) {
+            if (nextTime == null) {
               return false;
             }
-            nextReminder.setTime(new DateTime(moment(nextTime), true));
-            nextReminder.setDueDate(
-              new DateTime(moment(nextDueDate), dueDate.hasTimePart),
+            nextReminder.setTime(
+              new DateTime(moment(nextTime), time.hasTimePart),
             );
+            // `dueDate` may legitimately be absent here (an ⏰-only, or
+            // ⏳-only/🛫-only via fallback, line with no 📅): just skip
+            // advancing the due date rather than failing the whole
+            // recurrence.
+            if (dueDate != null) {
+              const nextDueDate: Date | undefined = nextOccurrence(
+                recurrence,
+                dueDate.moment(),
+                now,
+              );
+              if (nextDueDate == null) {
+                return false;
+              }
+              nextReminder.setDueDate(
+                new DateTime(moment(nextDueDate), dueDate.hasTimePart),
+              );
+            }
           } else {
+            // The due date is the only source of the recurrence date in
+            // this branch, so it must be present.
+            if (dueDate == null) {
+              return false;
+            }
             const next: Date | undefined = nextOccurrence(
               recurrence,
               dueDate.moment(),

--- a/src/model/format/reminder-tasks-plugin.test.ts
+++ b/src/model/format/reminder-tasks-plugin.test.ts
@@ -230,14 +230,191 @@ describe("TasksPluginReminderLine", (): void => {
   });
 });
 
+describe("TasksPluginReminderModel - reminder-time fallback (⏰ → 📅 → ⏳ → 🛫)", (): void => {
+  test("fallback off, custom emoji off: reads 📅 regardless of ⏰/⏳/🛫 presence", (): void => {
+    const spans = parseLine(
+      "- [ ] Task ⏰ 2021-09-10 📅 2021-09-08 ⏳ 2021-09-05 🛫 2021-09-01",
+    );
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.reminder.time.toString()).toBe("2021-09-08");
+  });
+
+  test("legacy (fallback off, custom emoji on): 📅 without ⏰ is not recognized", (): void => {
+    const spans = parseLine("- [ ] Task 📅 2021-09-08", { customEmoji: true });
+    expect(spans).toHaveLength(0);
+  });
+
+  test("legacy (fallback off, custom emoji on): ⏰ + 📅 both present reads ⏰", (): void => {
+    const spans = parseLine("- [ ] Task ⏰ 2021-09-10 📅 2021-09-08", {
+      customEmoji: true,
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.reminder.time.toString()).toBe("2021-09-10");
+  });
+
+  test("legacy (fallback off, custom emoji on): ⏰ without 📅 is not recognized (unchanged)", (): void => {
+    const spans = parseLine("- [ ] Task ⏰ 2021-09-10", { customEmoji: true });
+    expect(spans).toHaveLength(0);
+  });
+
+  test("fallback on: falls back to 📅 when ⏰ is absent (#67)", (): void => {
+    const spans = parseLine("- [ ] Task 📅 2021-09-08", {
+      customEmoji: true,
+      dueDateFallback: true,
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.reminder.time.toString()).toBe("2021-09-08");
+  });
+
+  test("fallback on: falls back to ⏳ when ⏰ and 📅 are absent (#113, ⏳-only)", (): void => {
+    const spans = parseLine("- [ ] Task ⏳ 2021-09-05", {
+      customEmoji: true,
+      dueDateFallback: true,
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.reminder.time.toString()).toBe("2021-09-05");
+  });
+
+  test("fallback on: falls back to 🛫 when ⏰, 📅, and ⏳ are absent", (): void => {
+    const spans = parseLine("- [ ] Task 🛫 2021-09-01", {
+      customEmoji: true,
+      dueDateFallback: true,
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.reminder.time.toString()).toBe("2021-09-01");
+  });
+
+  test("fallback on: 📅 outranks ⏳ when both are present (intentional priority-ranking gap)", (): void => {
+    const spans = parseLine("- [ ] Task 📅 2021-09-08 ⏳ 2021-09-05", {
+      customEmoji: true,
+      dueDateFallback: true,
+    });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.reminder.time.toString()).toBe("2021-09-08");
+  });
+
+  test("fallback on: a malformed ⏰ blocks fallback to a valid 📅 (presence, not validity)", (): void => {
+    const spans = parseLine("- [ ] Task ⏰ not-a-date 📅 2021-09-08", {
+      customEmoji: true,
+      dueDateFallback: true,
+    });
+    expect(spans).toHaveLength(0);
+  });
+
+  describe("appendReminder() gate parity", (): void => {
+    const line = "- [ ] Task ⏰ 2021-09-13 09:00";
+    const time = new DateTime(moment("2021-09-20 10:00"), true);
+
+    test("fallback on: the ⏰-only line is already tracked, so appendReminder() only calls setTime() and does not back-fill 📅", (): void => {
+      const sut = new TasksPluginFormat();
+      const config = new ReminderFormatConfig();
+      config.setParameterValue(
+        ReminderFormatParameterKey.useCustomEmojiForTasksPlugin,
+        true,
+      );
+      config.setParameterValue(
+        ReminderFormatParameterKey.useReminderTimeFallbackForTasksPlugin,
+        true,
+      );
+      sut.setConfig(config);
+      const inserted = sut.appendReminder(line, time);
+      expect(inserted!.insertedLine).toContain("⏰ 2021-09-20 10:00");
+      expect(inserted!.insertedLine).not.toContain("📅");
+    });
+
+    test("fallback off: the same ⏰-only line is not tracked, so appendReminder() goes through newReminder() and back-fills 📅", (): void => {
+      const sut = new TasksPluginFormat();
+      const config = new ReminderFormatConfig();
+      config.setParameterValue(
+        ReminderFormatParameterKey.useCustomEmojiForTasksPlugin,
+        true,
+      );
+      sut.setConfig(config);
+      const inserted = sut.appendReminder(line, time);
+      expect(inserted!.insertedLine).toContain("📅");
+    });
+  });
+
+  describe("recurrence / #106: ⏰-only recurring line with no 📅", (): void => {
+    test("fallback on: regenerates with an advanced ⏰ and no fabricated 📅", async () => {
+      await testModify({
+        now: "2021-09-13 09:10",
+        customEmoji: true,
+        dueDateFallback: true,
+        inputMarkdown: "- [ ] Task ⏰ 2021-09-13 09:00 🔁 every day",
+        expectedMarkdown: `- [ ] Task ⏰ 2021-09-14 09:00 🔁 every day
+- [x] Task ⏰ 2021-09-13 09:00 🔁 every day ✅ 2021-09-13`,
+      });
+    });
+
+    test("fallback off: the same line never becomes a tracked reminder (gate rejects before recurrence is reachable)", async () => {
+      await testModify({
+        now: "2021-09-13 09:10",
+        customEmoji: true,
+        dueDateFallback: false,
+        inputMarkdown: "- [ ] Task ⏰ 2021-09-13 09:00 🔁 every day",
+        expectedMarkdown: undefined,
+      });
+    });
+  });
+
+  describe("recurrence hasTimePart fix: date-only ⏰ stays date-only (both fallback modes)", (): void => {
+    test("fallback on: date-only ⏰ recurring line (with 📅 present) regenerates without a fabricated 00:00", async () => {
+      await testModify({
+        now: "2021-09-13",
+        customEmoji: true,
+        dueDateFallback: true,
+        inputMarkdown: "- [ ] Task ⏰ 2021-09-12 🔁 every day 📅 2021-09-12",
+        expectedMarkdown: `- [ ] Task ⏰ 2021-09-14 🔁 every day 📅 2021-09-14
+- [x] Task ⏰ 2021-09-12 🔁 every day 📅 2021-09-12 ✅ 2021-09-13`,
+      });
+    });
+
+    test("fallback off: date-only ⏰ recurring line (with 📅 present) regenerates without a fabricated 00:00", async () => {
+      await testModify({
+        now: "2021-09-13",
+        customEmoji: true,
+        dueDateFallback: false,
+        inputMarkdown: "- [ ] Task ⏰ 2021-09-12 🔁 every day 📅 2021-09-12",
+        expectedMarkdown: `- [ ] Task ⏰ 2021-09-14 🔁 every day 📅 2021-09-14
+- [x] Task ⏰ 2021-09-12 🔁 every day 📅 2021-09-12 ✅ 2021-09-13`,
+      });
+    });
+  });
+});
+
+function parseLine(
+  markdown: string,
+  options: { customEmoji?: boolean; dueDateFallback?: boolean } = {},
+) {
+  const sut = new TasksPluginFormat();
+  const config = new ReminderFormatConfig();
+  if (options.customEmoji !== undefined) {
+    config.setParameterValue(
+      ReminderFormatParameterKey.useCustomEmojiForTasksPlugin,
+      options.customEmoji,
+    );
+  }
+  if (options.dueDateFallback !== undefined) {
+    config.setParameterValue(
+      ReminderFormatParameterKey.useReminderTimeFallbackForTasksPlugin,
+      options.dueDateFallback,
+    );
+  }
+  sut.setConfig(config);
+  return sut.parse(new MarkdownDocument("file", markdown));
+}
+
 async function testModify({
   now,
   customEmoji,
+  dueDateFallback = false,
   inputMarkdown,
   expectedMarkdown,
 }: {
   now: string;
   customEmoji: boolean;
+  dueDateFallback?: boolean;
   inputMarkdown: string;
   expectedMarkdown: string | undefined;
 }) {
@@ -251,6 +428,10 @@ async function testModify({
   config.setParameterValue(
     ReminderFormatParameterKey.useCustomEmojiForTasksPlugin,
     customEmoji,
+  );
+  config.setParameterValue(
+    ReminderFormatParameterKey.useReminderTimeFallbackForTasksPlugin,
+    dueDateFallback,
   );
   sut.setConfig(config);
 

--- a/src/model/format/reminder-tasks-plugin.ts
+++ b/src/model/format/reminder-tasks-plugin.ts
@@ -34,11 +34,13 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
     useCustomEmoji?: boolean,
     removeTags?: boolean,
     strictDateFormat?: boolean,
+    useDueDateFallback?: boolean,
   ): TasksPluginReminderModel {
     return new TasksPluginReminderModel(
       useCustomEmoji ?? false,
       removeTags ?? false,
       strictDateFormat ?? true,
+      useDueDateFallback ?? false,
       new Tokens(splitBySymbol(line, this.allSymbols)),
     );
   }
@@ -47,6 +49,7 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
     private useCustomEmoji: boolean,
     private removeTags: boolean,
     private strictDateFormat: boolean,
+    private useDueDateFallback: boolean,
     private tokens: Tokens,
   ) {}
 
@@ -58,13 +61,13 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
     return title;
   }
   getTime(): DateTime | null {
-    return this.getDate(this.getReminderSymbol());
+    return this.getDate(this.resolveReminderSymbol());
   }
   setTime(time: DateTime, insertAt?: number): void {
     if (this.useCustomEmoji) {
-      this.setDate(this.getReminderSymbol(), time, 1);
+      this.setDate(this.writeReminderSymbol(), time, 1);
     } else {
-      this.setDate(this.getReminderSymbol(), time, insertAt);
+      this.setDate(this.writeReminderSymbol(), time, insertAt);
     }
   }
   getDueDate(): DateTime | null {
@@ -74,10 +77,46 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
     this.setDate(TasksPluginReminderModel.symbolDueDate, time);
   }
   setRawTime(rawTime: string): boolean {
-    this.setDate(this.getReminderSymbol(), rawTime);
+    this.setDate(this.writeReminderSymbol(), rawTime);
     return true;
   }
-  private getReminderSymbol(): Symbol {
+
+  /**
+   * Symbol used to read the reminder time. Unlike `writeReminderSymbol()`,
+   * this may cascade through 📅/⏳/🛫 when the fallback setting is on, so
+   * reads and writes intentionally use different symbol-resolution rules
+   * (see design doc "Reminder-time resolution rule").
+   */
+  private resolveReminderSymbol(): Symbol {
+    if (!this.useCustomEmoji) {
+      return TasksPluginReminderModel.symbolDueDate;
+    }
+    if (!this.useDueDateFallback) {
+      return TasksPluginReminderModel.symbolReminder;
+    }
+    const chain = [
+      TasksPluginReminderModel.symbolReminder,
+      TasksPluginReminderModel.symbolDueDate,
+      TasksPluginReminderModel.symbolScheduled,
+      TasksPluginReminderModel.symbolStart,
+    ];
+    for (const symbol of chain) {
+      // Fallback is based on token presence, not parse validity: a
+      // malformed higher-priority token still blocks fallback to a
+      // lower-priority one.
+      if (this.tokens.getToken(symbol) != null) {
+        return symbol;
+      }
+    }
+    return TasksPluginReminderModel.symbolReminder;
+  }
+
+  /**
+   * Symbol used to write the reminder time (snooze). Always ⏰ in
+   * custom-emoji mode, independent of the fallback setting, so snoozing
+   * never clobbers 📅/⏳/🛫.
+   */
+  private writeReminderSymbol(): Symbol {
     if (this.useCustomEmoji) {
       return TasksPluginReminderModel.symbolReminder;
     } else {
@@ -87,11 +126,7 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
 
   getEndOfTimeTextIndex(): number {
     // get the end of the string index of due date or reminder date
-    let timeSymbol = TasksPluginReminderModel.symbolDueDate;
-    if (this.useCustomEmoji) {
-      timeSymbol = TasksPluginReminderModel.symbolReminder;
-    }
-    const token = this.tokens.rangeOfSymbol(timeSymbol);
+    const token = this.tokens.rangeOfSymbol(this.resolveReminderSymbol());
     if (token != null) {
       return token.end;
     }
@@ -99,7 +134,7 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
   }
 
   computeSpan(): { start: number; end: number } {
-    const symbol = this.getReminderSymbol();
+    const symbol = this.resolveReminderSymbol();
     const range = this.tokens.rangeOfSymbol(symbol);
     const token = this.tokens.getToken(symbol);
     if (range == null || token == null) {
@@ -147,6 +182,7 @@ export class TasksPluginReminderModel implements TasksLikeReminderModel {
       this.useCustomEmoji,
       this.removeTags,
       this.strictDateFormat,
+      this.useDueDateFallback,
     );
   }
 
@@ -251,9 +287,18 @@ export class TasksPluginFormat extends TasksLikeReminderFormat<TasksPluginRemind
       this.useCustomEmoji(),
       this.removeTagsEnabled(),
       this.isStrictDateFormat(),
+      this.useDueDateFallback(),
     );
-    if (this.useCustomEmoji() && parsed.getDueDate() == null) {
-      return null;
+    if (this.useCustomEmoji()) {
+      if (this.useDueDateFallback()) {
+        if (parsed.getTime() == null) {
+          return null;
+        }
+      } else {
+        if (parsed.getDueDate() == null) {
+          return null;
+        }
+      }
     }
     return parsed;
   }
@@ -267,6 +312,12 @@ export class TasksPluginFormat extends TasksLikeReminderFormat<TasksPluginRemind
   private useCustomEmoji() {
     return this.config.getParameter(
       ReminderFormatParameterKey.useCustomEmojiForTasksPlugin,
+    );
+  }
+
+  private useDueDateFallback() {
+    return this.config.getParameter(
+      ReminderFormatParameterKey.useReminderTimeFallbackForTasksPlugin,
     );
   }
 
@@ -284,6 +335,7 @@ export class TasksPluginFormat extends TasksLikeReminderFormat<TasksPluginRemind
       this.useCustomEmoji(),
       this.removeTagsEnabled(),
       this.isStrictDateFormat(),
+      this.useDueDateFallback(),
     );
     parsed.setTime(time, insertAt);
     if (this.useCustomEmoji() && parsed.getDueDate() == null) {

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -48,6 +48,7 @@ export class Settings {
   primaryFormat: SettingModel<string, ReminderFormatType>;
   excludedPaths: SettingModel<string, Array<string>>;
   useCustomEmojiForTasksPlugin: SettingModel<boolean, boolean>;
+  useReminderTimeFallbackForTasksPlugin: SettingModel<boolean, boolean>;
   removeTagsForTasksPlugin: SettingModel<boolean, boolean>;
   dataviewReminderFieldName: SettingModel<string, string>;
   linkDatesToDailyNotes: SettingModel<boolean, boolean>;
@@ -306,6 +307,22 @@ export class Settings {
         );
       })
       .build(new RawSerde());
+    this.useReminderTimeFallbackForTasksPlugin = this.settings
+      .newSettingBuilder()
+      .key("useReminderTimeFallbackForTasksPlugin")
+      .name("Fall back to due, scheduled, or start date")
+      .desc(
+        "When the reminder date (⏰) is missing, use the due date (📅), then the scheduled date (⏳), then the start date (🛫), in that order.",
+      )
+      .tag(TAG_RESCAN)
+      .toggle(false)
+      .onAnyValueChanged((context) => {
+        context.setEnabled(
+          reminderFormatSettings.enableTasksPluginReminderFormat.value &&
+            this.useCustomEmojiForTasksPlugin.value,
+        );
+      })
+      .build(new RawSerde());
     this.removeTagsForTasksPlugin = this.settings
       .newSettingBuilder()
       .key("removeTagsForTasksPlugin")
@@ -448,6 +465,7 @@ export class Settings {
       .addSettings(
         reminderFormatSettings.enableTasksPluginReminderFormat,
         this.useCustomEmojiForTasksPlugin,
+        this.useReminderTimeFallbackForTasksPlugin,
         this.removeTagsForTasksPlugin,
       );
     reminderFormatsPage
@@ -493,6 +511,10 @@ export class Settings {
     config.setParameter(
       ReminderFormatParameterKey.removeTagsForTasksPlugin,
       this.removeTagsForTasksPlugin,
+    );
+    config.setParameter(
+      ReminderFormatParameterKey.useReminderTimeFallbackForTasksPlugin,
+      this.useReminderTimeFallbackForTasksPlugin,
     );
     config.setParameter(
       ReminderFormatParameterKey.dataviewReminderFieldName,


### PR DESCRIPTION
## Summary

- When "Distinguish between reminder date and due date" is enabled, a Tasks-plugin task line was only recognized as a reminder if ⏰ was explicitly present. Users repeatedly asked for a fallback to due (📅), scheduled (⏳), or start (🛫) dates instead (#67, #113, #106).
- Add a new opt-in setting, "Fall back to due, scheduled, or start date" (`useReminderTimeFallbackForTasksPlugin`), that resolves the reminder time via the priority chain ⏰ → 📅 → ⏳ → 🛫 when enabled. Default off, so existing custom-emoji users see no behavior change unless they opt in.
- Read and write paths use different symbol-resolution rules by design: snooze ("remind me later") still always writes ⏰ and never overwrites 📅/⏳/🛫, satisfying #67's "don't clobber the due date" requirement.
- Fixes #67 and #106 (recurring ⏰-only lines with no 📅 now recur correctly). Partially addresses #113 — ⏳-only and 🛫-only lines are now recognized, but when both 📅 and ⏳ are present, 📅 still wins by design (rationale in the design doc).
- #211 remains unfixed: its root cause is the native Tasks plugin's own recurrence regenerating the line outside this plugin's modify path, which is out of scope here.
- Side effect: the same recurrence-regeneration fix (relocating a due-date-required guard, fixing a hardcoded `hasTimePart: true`) also makes Dataview `reminder::`-only recurring lines work, since that guard was previously reachable unconditionally there and silently failed.
- Full design writeup (produced via a sonnet-design / fable-review loop, 4 rounds to convergence): `design/tasks-plugin-reminder-fallback.md` (not committed to this branch — repo-local working note).

## Test plan

- [x] `npm run test` — 220/220 passing (67 new/updated cases in `reminder-tasks-plugin.test.ts` / `reminder-dataview.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint:fix` — clean
- [x] Manual verification in test vault — settings toggle visibility/gating, fallback priority (⏳-only, 🛫-only, 📅+⏳ prefers 📅), legacy behavior unchanged with fallback off, snooze preserves 📅, ⏰-only recurring lines recur correctly, Dataview `reminder::`-only recurring lines recur correctly. All confirmed working.