### PR TITLE
Extend the stale workflow to auto-close awaiting-response issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close stale awaiting-response PRs
+name: Close stale awaiting-response issues and PRs
 
 on:
   schedule:
@@ -28,18 +28,20 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          # Only PRs explicitly labeled by a maintainer are subject to auto-close.
+          # Only issues/PRs explicitly labeled by a maintainer are subject to auto-close.
           any-of-pr-labels: awaiting-response
+          any-of-issue-labels: awaiting-response
           # Manual runs are dry runs by default; scheduled runs always act.
           debug-only: ${{ inputs.debug-only == true }}
           days-before-stale: ${{ inputs.days-before-stale || 30 }}
           days-before-close: ${{ inputs.days-before-close || 7 }}
-          # Issues are out of scope for now.
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
+          days-before-issue-stale: ${{ inputs.days-before-stale || 30 }}
+          days-before-issue-close: ${{ inputs.days-before-close || 7 }}
           exempt-draft-pr: true
           exempt-pr-labels: pinned
+          exempt-issue-labels: pinned
           stale-pr-label: stale
+          stale-issue-label: stale
           stale-pr-message: >
             This pull request has been marked as stale because it has been
             awaiting a response from the author for 30 days. It will be closed
@@ -51,3 +53,13 @@ jobs:
             author after the stale notice. Thank you for the contribution — if
             you would like to continue, feel free to reopen it or submit a new
             pull request against the latest master.
+          stale-issue-message: >
+            This issue has been marked as stale because it has been awaiting a
+            response for 30 days. It will be closed in 7 days if there is no
+            further activity. If this is still relevant, just leave a comment
+            — that resets the timer.
+          close-issue-message: >
+            Closing this issue because there was no response after the stale
+            notice. If this is still happening on the latest version, feel
+            free to reopen it with updated details (version, reproduction
+            steps).


### PR DESCRIPTION
## Summary

- `.github/workflows/stale.yml` previously only applied the 30-day-stale / 7-day-close cycle to PRs labeled `awaiting-response`; issues were explicitly excluded (`days-before-issue-stale: -1`).
- Apply the same mechanism to issues labeled `awaiting-response`, sharing the same day thresholds and `debug-only`/dry-run behavior as PRs.
- This lets triage comments that ask a reporter for reproduction info or confirmation (e.g. #113, #211) actually resolve on their own after a month of silence, instead of accumulating indefinitely.
- `awaiting-response`/`stale`/`pinned` labels already exist in the repo, so no label setup is needed.

## Test plan

- [x] `actionlint .github/workflows/stale.yml` — clean
- [x] YAML parses correctly (`js-yaml`)
- [ ] Manual trigger with `debug-only: true` after merge to confirm the dry-run log looks correct for currently-labeled issues, if any