### PR TITLE
Add uphy's copyright line to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 MIT License
 
-Copyright (c) 2021 Liam Cain
 Copyright (c) 2021 uphy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Liam Cain
-Copyright (c) 2021-2026 uphy
+Copyright (c) 2021 uphy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Liam Cain
+Copyright (c) 2021-2026 uphy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Replaces the LICENSE's copyright holder (`Liam Cain`, left over from the template this repo started from) with `uphy`, the actual maintainer of this fork.

Closes #149

## Test plan
- [x] N/A — documentation-only change