### PR TITLE
Auto-dismiss toast reminders when edited past their expiry

### DIFF
--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -136,6 +136,11 @@ export class ReminderPluginUI {
   invalidate() {
     this.viewProxy.invalidate();
     this.overdueStatusBar.refresh();
+    this.reminderModal.syncToasts(
+      new Set(
+        this.plugin.reminders.reminders.map((reminder) => reminder.key()),
+      ),
+    );
   }
 
   reload(force: boolean = false) {

--- a/src/plugin/ui/reminder-toast.ts
+++ b/src/plugin/ui/reminder-toast.ts
@@ -90,6 +90,21 @@ export class ReminderToastManager {
     this.containerEl = undefined;
   }
 
+  /**
+   * Removes any toast whose reminder key is no longer present in the
+   * current data (e.g. its date was edited into the future, the line was
+   * deleted, or the task was checked off directly in the file). Does not
+   * invoke onCancel/onDone -- the reminder simply no longer matches what's
+   * displayed, it wasn't acted on.
+   */
+  sync(currentKeys: Set<string>) {
+    for (const key of Array.from(this.toasts.keys())) {
+      if (!currentKeys.has(key)) {
+        this.remove(key);
+      }
+    }
+  }
+
   private remove(key: string) {
     const entry = this.toasts.get(key);
     if (!entry) {

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -24,6 +24,11 @@ export class ReminderModal {
     this.toastManager.destroy();
   }
 
+  /** Delegates to the toast manager; a no-op when in modal mode (no toasts exist). */
+  syncToasts(currentKeys: Set<string>) {
+    this.toastManager.sync(currentKeys);
+  }
+
   public show(
     reminder: Reminder,
     onRemindMeLater: (time: DateTime) => void,


### PR DESCRIPTION
## Summary
- Toast-style reminder popups (`notificationPopupStyle: "toast"`) now automatically disappear when the underlying reminder no longer matches the live data — e.g. editing the date to the future, deleting the line, or checking the task off directly in the file.
- Previously, a shown toast was a disconnected snapshot: it stayed on screen until the user manually clicked Done/Mute/Close, even after the reminder was no longer overdue.

## Approach
`Reminder.key()` (`file + title + time`) doesn't depend on row number, so detecting staleness doesn't require tracking a reminder's identity across an edit — it's enough to check whether a displayed toast's key is still present in the current `Reminders` data.

- `ReminderToastManager.sync(currentKeys)`: removes any toast whose key is no longer in the given set (without invoking `onCancel`/`onDone`, since the reminder wasn't acted on).
- `ReminderModal.syncToasts(currentKeys)`: delegates to the toast manager (no-op in modal mode, since no toasts exist there).
- `ReminderPluginUI.invalidate()` — the single hook that fires on every `Reminders` data change (file modify/delete/rename, task completion, etc.) — calls `syncToasts()` with the current key set.

## Test plan
- [x] `npm run test` (220 tests, all passing; no `src/model/` code touched)
- [x] `npx tsc --noEmit` / `eslint` clean
- [x] Manually verified in a test vault: a task with a past date shows a toast; editing the date to a future date auto-dismisses the toast; reverting to a past date re-shows a new toast (regression check for normal toast flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)