### PR TITLE
Ignore tasks inside fenced code blocks

### DIFF
--- a/src/model/format/markdown.test.ts
+++ b/src/model/format/markdown.test.ts
@@ -84,6 +84,145 @@ describe("MarkdownDocument", (): void => {
     expect(todos[1]!.isChecked()).toBe(true);
     expect(todos[2]!.isChecked()).toBe(true);
   });
+
+  test("tasks inside a fenced code block are ignored", (): void => {
+    const md = `- [ ] Before
+\`\`\`
+- [ ] Inside fence
+\`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(4, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("tasks inside a ~~~ fenced code block are ignored", (): void => {
+    const md = `- [ ] Before
+~~~
+- [ ] Inside fence
+~~~
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(4, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("a fence with an info string is still recognized as a fence", (): void => {
+    const md = `- [ ] Before
+\`\`\`markdown
+- [ ] Inside fence
+\`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(4, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("a fence indented inside a list item is recognized", (): void => {
+    const md = `- [ ] Before
+- [ ] List item
+      \`\`\`
+      - [ ] Inside fence
+      \`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(1, "- [", " ", "] ", "List item"),
+      new Todo(5, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("a longer fence is not closed by a shorter fence of the same character inside it", (): void => {
+    const md = `- [ ] Before
+\`\`\`\`
+\`\`\`
+- [ ] Inside fence
+\`\`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(5, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("an unclosed fence extends to the end of the document", (): void => {
+    const md = `- [ ] Before
+\`\`\`
+- [ ] Inside fence
+- [ ] Also inside fence`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([new Todo(0, "- [", " ", "] ", "Before")]);
+  });
+
+  test("a fence inside a blockquote is recognized", (): void => {
+    const md = `- [ ] Before
+> \`\`\`
+> - [ ] Inside fence
+> \`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(4, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("a fence inside an indented blockquote is recognized", (): void => {
+    const md = `- [ ] Before
+  > \`\`\`
+  > - [ ] Inside fence
+  > \`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([
+      new Todo(0, "- [", " ", "] ", "Before"),
+      new Todo(4, "- [", " ", "] ", "After"),
+    ]);
+  });
+
+  test("a line starting with an inline code span does not open a fence", (): void => {
+    const md = `\`\`\`inline\`\`\` is not a fence
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    const todos = doc.getTodos();
+    expect(todos).toStrictEqual([new Todo(1, "- [", " ", "] ", "After")]);
+  });
+
+  test("toMarkdown() round-trips a document with code blocks unchanged", (): void => {
+    const md = `- [ ] Before
+\`\`\`
+- [ ] Inside fence
+\`\`\`
+- [ ] After`;
+
+    const doc = new MarkdownDocument("file", md);
+    expect(doc.toMarkdown()).toEqual(md);
+  });
 });
 
 describe("convertToTodoLine()", (): void => {

--- a/src/model/format/markdown.ts
+++ b/src/model/format/markdown.ts
@@ -126,10 +126,52 @@ export class MarkdownDocument {
     this.parse(content);
   }
 
+  // Code fence delimiter: 3 or more backticks or tildes, preceded only by
+  // indentation and blockquote markers.  Indentation is accepted regardless of
+  // its width because fences nested in list items are often indented by more
+  // than the 3 spaces CommonMark allows at the top level.  Indented (4-space)
+  // code blocks are deliberately not detected: a 4-space indented "- [ ]" line
+  // is an ordinary nested list item.
+  private static readonly fenceRegexp =
+    /^\s*(?:> ?)*\s*(?<fence>`{3,}|~{3,})(?<info>.*)$/;
+
   private parse(content: string) {
     this.lines = content.split("\n");
     this.todos = [];
+
+    // Fence character ("`" or "~") and length of the currently open fenced
+    // code block, or null when not inside one.
+    let openFenceChar: string | null = null;
+    let openFenceLength = 0;
+
     this.lines.forEach((line, lineIndex) => {
+      const fenceMatch = MarkdownDocument.fenceRegexp.exec(line);
+      const fence = fenceMatch?.groups!["fence"];
+      const info = fenceMatch?.groups!["info"];
+
+      if (openFenceChar === null) {
+        // A backtick fence's info string must not contain a backtick,
+        // otherwise this is an inline code span, not a fence.
+        if (fence !== undefined && (fence[0] !== "`" || !info!.includes("`"))) {
+          openFenceChar = fence[0]!;
+          openFenceLength = fence.length;
+          return;
+        }
+      } else {
+        // A closing fence repeats the opening character at least as many times,
+        // and carries nothing but whitespace after it.
+        if (
+          fence !== undefined &&
+          fence[0] === openFenceChar &&
+          fence.length >= openFenceLength &&
+          info!.trim() === ""
+        ) {
+          openFenceChar = null;
+        }
+        // Lines inside a fenced code block are never treated as todos.
+        return;
+      }
+
       const todo = Todo.parse(lineIndex, line);
       if (todo) {
         this.todos.push(todo);


### PR DESCRIPTION
Fixes #338.

Tasks written inside a fenced code block were parsed as real reminders: they showed up in the reminder list, got a pill in the editor, and fired notifications.

## Change

`MarkdownDocument.parse()` now tracks fenced-code-block state while scanning lines and registers no `Todo` for lines inside a block. This is the single entry point every consumer goes through (reminder parsing / notifications via `getTodos()`, and the CM6 editor pill widgets), so one fix covers all of them.

Fence rules:

- An opening fence is 3 or more backticks or tildes, preceded only by indentation and blockquote markers (`> `).
- A closing fence repeats the opening character at least as many times and carries nothing but whitespace after it, so a ``` line inside a ```` block doesn't close it.
- A backtick fence whose info string contains a backtick isn't a fence, so a line starting with an inline code span isn't mistaken for one.
- An unclosed fence extends to the end of the document.

Indentation is accepted regardless of width, because fences nested in list items are often indented by more than the 3 spaces CommonMark allows at the top level. Indented (4-space) code blocks are deliberately not detected: a 4-space indented `- [ ]` line is an ordinary nested list item.

Line indices and the `lines` array are untouched, so `toMarkdown()` still round-trips unchanged; only the `todos` array shrinks.

## Tests

10 tests added to `src/model/format/markdown.test.ts`: ``` and `~~~` fences, a fence with an info string, a fence indented inside a list item, a longer fence containing a shorter one, an unclosed fence, fences inside a blockquote (plain and indented), a line starting with an inline code span, and a `toMarkdown()` round-trip. Full suite: 232 passed.

## Manual verification

Verified in a test vault: with tasks in ``` / `~~~` / list-indented / blockquote / nested fences, only the two tasks outside the fences appear in the reminder list and get editor pills; the five inside are ignored. Inserting a reminder with the `(@` autocomplete, jumping to a line from the reminder list, and checking a task off still work.

## Known limitation (out of scope)

Inserting a date into a task line that sits inside a code block still succeeds (`appendReminder` sees one line without surrounding context), so the insertion is possible while the result is never recognized. Left for a separate issue.