### PR TITLE
Dismiss system notifications when a reminder is resolved on another device

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -62,6 +62,8 @@ Instead of built-in notification, a system notification is also available by [se
 
 Also, if you are using macOS, you can mark it as done or postpone the reminder with the notification options.
 
+If you use the same vault on multiple devices (for example with Obsidian Sync), completing or snoozing a reminder on one device can automatically dismiss its system notification on your other devices. On macOS this already works without any extra setup. On Windows and Linux, the OS only lets the plugin dismiss a notification while it's still on screen, so this also requires enabling [Keep system notification on screen](/setting/#keep-system-notification-on-screen) there -- otherwise the notification may already have moved to the action center/notification tray by the time the dismissal arrives.
+
 ### Showing the popup together with the system notification
 
 If you'd rather not lose the popup's actions, enable [Show popup together with system notification](/setting/#show-popup-together-with-system-notification) alongside `Use system notification`. The built-in reminder popup is then shown at the same time as the system notification, and the popup becomes the surface that handles the reminder actions (mark as done/remind me later/mute/open note). The system notification acts as an alert only: clicking it just closes it, or opens the note directly when [Open note on reminder click](/setting/#open-note-on-reminder-click) is enabled.

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -84,6 +84,20 @@ Only takes effect while [Use system notification](#use-system-notification) is e
   - OFF: Only the system notification is shown, and it handles the reminder actions itself.
 - Default: OFF
 
+### Keep system notification on screen
+
+Keep the system notification on screen until you interact with it, instead of it disappearing after a few seconds.
+
+Only effective on Windows and Linux; ignored on macOS.
+
+Enable this if you use the same vault on multiple devices (e.g. via Obsidian Sync): it allows the plugin to dismiss the notification when you complete or snooze the reminder on another device.
+
+- Type: `boolean`
+- Values:
+  - ON: The notification stays on screen until dismissed
+  - OFF: The notification disappears on its own after a few seconds (default)
+- Default: OFF
+
 ### Focus Done button on popup
 
 Automatically focus the Done button when a reminder popup opens, so pressing Enter completes the task. Off by default to prevent accidentally completing a reminder you haven't read.

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -36,6 +36,7 @@ export class Settings {
   openNoteOnReminderClick: SettingModel<boolean, boolean>;
   useSystemNotification: SettingModel<boolean, boolean>;
   showPopupWithSystemNotification: SettingModel<boolean, boolean>;
+  keepSystemNotificationOnScreen: SettingModel<boolean, boolean>;
   focusDoneButtonOnPopup: SettingModel<boolean, boolean>;
   laters: SettingModel<string, Array<Later>>;
   weekStart: SettingModel<string, string>;
@@ -127,6 +128,16 @@ export class Settings {
       .name("Show popup together with system notification")
       .desc(
         "When using system notification, also show the built-in reminder popup at the same time. The popup handles the reminder actions; the system notification acts as an alert only.",
+      )
+      .toggle(false)
+      .build(new RawSerde());
+
+    this.keepSystemNotificationOnScreen = this.settings
+      .newSettingBuilder()
+      .key("keepSystemNotificationOnScreen")
+      .name("Keep system notification on screen")
+      .desc(
+        "Keep the system notification on screen until you interact with it, instead of it disappearing after a few seconds. Only effective on Windows and Linux; ignored on macOS. Enable this if you use the same vault on multiple devices (e.g. via Obsidian Sync): it allows the plugin to dismiss the notification when you complete or snooze the reminder on another device.",
       )
       .toggle(false)
       .build(new RawSerde());
@@ -430,6 +441,7 @@ export class Settings {
         this.openNoteOnReminderClick,
         this.useSystemNotification,
         this.showPopupWithSystemNotification,
+        this.keepSystemNotificationOnScreen,
         this.focusDoneButtonOnPopup,
         this.showOverdueCountInStatusBar,
       );

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -130,6 +130,9 @@ export class Settings {
         "When using system notification, also show the built-in reminder popup at the same time. The popup handles the reminder actions; the system notification acts as an alert only.",
       )
       .toggle(false)
+      .onAnyValueChanged((context) => {
+        context.setEnabled(this.useSystemNotification.value);
+      })
       .build(new RawSerde());
 
     this.keepSystemNotificationOnScreen = this.settings
@@ -140,6 +143,9 @@ export class Settings {
         "Keep the system notification on screen until you interact with it, instead of it disappearing after a few seconds. Only effective on Windows and Linux; ignored on macOS. Enable this if you use the same vault on multiple devices (e.g. via Obsidian Sync): it allows the plugin to dismiss the notification when you complete or snooze the reminder on another device.",
       )
       .toggle(false)
+      .onAnyValueChanged((context) => {
+        context.setEnabled(this.useSystemNotification.value);
+      })
       .build(new RawSerde());
 
     this.focusDoneButtonOnPopup = this.settings

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -66,6 +66,7 @@ export class ReminderPluginUI {
       plugin.settings.laters,
       plugin.settings.openNoteOnReminderClick,
       plugin.settings.showPopupWithSystemNotification,
+      plugin.settings.keepSystemNotificationOnScreen,
       plugin.settings.focusDoneButtonOnPopup,
       plugin.settings.notificationPopupStyle,
     );
@@ -137,7 +138,7 @@ export class ReminderPluginUI {
   invalidate() {
     this.viewProxy.invalidate();
     this.overdueStatusBar.refresh();
-    this.reminderModal.syncToasts(
+    this.reminderModal.sync(
       new Set(
         this.plugin.reminders.reminders.map((reminder) => reminder.key()),
       ),

--- a/src/plugin/ui/reminder.ts
+++ b/src/plugin/ui/reminder.ts
@@ -6,8 +6,22 @@ import ReminderView from "ui/Reminder.svelte";
 import { ReminderToastManager } from "./reminder-toast";
 const electron = window.require ? window.require("electron") : undefined;
 
+/** A system notification tracked so it can be dismissed programmatically. */
+interface TrackedSystemNotification {
+  notification: { close: () => void };
+  // Set right before we call `notification.close()` ourselves (e.g. from
+  // `sync()`/`destroy()`, or replacing a stale notification for the same
+  // key), so the "close" event handler can tell that apart from the user
+  // dismissing the notification and skip calling `onMute()` again --
+  // `showReminder()` already marks the reminder muted at display time, so a
+  // second `onMute()` call would just trigger a redundant reload()/save().
+  closedByPlugin: boolean;
+}
+
 export class ReminderModal {
   private toastManager: ReminderToastManager = new ReminderToastManager();
+  private systemNotifications: Map<string, TrackedSystemNotification> =
+    new Map();
 
   constructor(
     private app: App,
@@ -15,18 +29,54 @@ export class ReminderModal {
     private laters: ReadOnlyReference<Array<Later>>,
     private openNoteOnReminderClick: ReadOnlyReference<boolean>,
     private showPopupWithSystemNotification: ReadOnlyReference<boolean>,
+    private keepSystemNotificationOnScreen: ReadOnlyReference<boolean>,
     private focusDoneButtonOnPopup: ReadOnlyReference<boolean>,
     private notificationPopupStyle: ReadOnlyReference<string>,
   ) {}
 
-  /** Unmounts every open toast (for plugin unload). */
+  /** Unmounts every open toast and closes every tracked system notification (for plugin unload). */
   destroy() {
     this.toastManager.destroy();
+    for (const key of Array.from(this.systemNotifications.keys())) {
+      this.closeSystemNotification(key);
+    }
+    this.systemNotifications.clear();
   }
 
-  /** Delegates to the toast manager; a no-op when in modal mode (no toasts exist). */
-  syncToasts(currentKeys: Set<string>) {
+  /**
+   * Removes toasts and closes system notifications whose reminder key is no
+   * longer present in the current data -- e.g. the reminder was marked done
+   * or snoozed on another device and synced in, its date was edited into the
+   * future, the line was deleted, or the task was checked off directly in
+   * the file.
+   */
+  sync(currentKeys: Set<string>) {
     this.toastManager.sync(currentKeys);
+    for (const key of Array.from(this.systemNotifications.keys())) {
+      if (!currentKeys.has(key)) {
+        this.closeSystemNotification(key);
+      }
+    }
+  }
+
+  /**
+   * Closes the tracked system notification for `key`, if any, marking it as
+   * closed by the plugin so the "close" event handler doesn't treat it as a
+   * user dismissal.
+   *
+   * Removes the map entry immediately rather than waiting for the "close"
+   * event: on Windows, once a notification has moved from the screen to the
+   * action center, `close()` is a no-op and never fires "close", which would
+   * otherwise leak this entry forever.
+   */
+  private closeSystemNotification(key: string) {
+    const tracked = this.systemNotifications.get(key);
+    if (!tracked) {
+      return;
+    }
+    tracked.closedByPlugin = true;
+    this.systemNotifications.delete(key);
+    tracked.notification.close();
   }
 
   public show(
@@ -89,13 +139,39 @@ export class ReminderModal {
     onMuteAll: () => void,
     alertOnly: boolean,
   ) {
+    const key = reminder.key();
+    // Replace rather than stack a second notification for the same reminder
+    // (e.g. it expires again before the previous notification was
+    // dismissed), mirroring how the toast manager replaces existing toasts
+    // by key.
+    this.closeSystemNotification(key);
+
     const Notification = (electron as any).remote.Notification;
     const n = new Notification({
       title: "Obsidian Reminder",
       body: reminder.title,
+      // "never" keeps the notification on screen (Windows/Linux only, see
+      // Electron docs -- ignored on macOS) until the user interacts with
+      // it, which is required for `notification.close()` to be able to
+      // dismiss it once it has moved to the notification center/action
+      // center. With "default", close() only works while the notification
+      // is still on screen.
+      timeoutType: this.keepSystemNotificationOnScreen.value
+        ? "never"
+        : "default",
     });
+    const tracked: TrackedSystemNotification = {
+      notification: n,
+      closedByPlugin: false,
+    };
+    this.systemNotifications.set(key, tracked);
+
     n.on("click", () => {
-      n.close();
+      // Not a behavior change: `showReminder()` already marks the reminder
+      // muted before displaying it, so routing this through the shared
+      // helper (which skips `onMute()`) matches the previous plain
+      // `n.close()` call.
+      this.closeSystemNotification(key);
       if (this.openNoteOnReminderClick.value) {
         onOpenFile();
         return;
@@ -112,10 +188,19 @@ export class ReminderModal {
         );
       }
     });
+    n.on("close", () => {
+      // For a plugin-initiated close, closeSystemNotification() already
+      // removed the map entry (see its docstring). This only has an effect
+      // for a genuine user dismissal, where the entry is still present.
+      if (this.systemNotifications.get(key) === tracked) {
+        this.systemNotifications.delete(key);
+      }
+      if (alertOnly || tracked.closedByPlugin) {
+        return;
+      }
+      onMute();
+    });
     if (!alertOnly) {
-      n.on("close", () => {
-        onMute();
-      });
       // Only for macOS
       {
         const laters = this.laters.value;


### PR DESCRIPTION
ref #340.

## What

Track every system (OS) notification the plugin shows, keyed by reminder key, and close it when that reminder is no longer expired -- e.g. it was marked done or snoozed on another device and synced in, its date was edited, or the task was checked off directly in the file. This is the same lifecycle the toast popups already had via `ReminderToastManager.sync()`; `ReminderModal.syncToasts()` is renamed to `sync()` and now covers both surfaces.

Also adds a **Keep system notification on screen** setting (off by default). It passes Electron's `timeoutType: "never"`, which keeps the notification visible until the user interacts with it.

## Why the setting is needed

On Windows, `notification.close()` maps to `ToastNotifier.Hide()`, which only removes a toast while it is still on screen -- Windows 11 moves toasts to the action center after a few seconds, and removing them from there needs `ToastNotificationHistory.Remove` via WinRT, which isn't reachable from Electron ([electron#32260](https://github.com/electron/electron/issues/32260) was closed as not planned). With `timeoutType: "never"` the notification stays on screen (`scenario="reminder"`), so the dismissal actually lands. `timeoutType` is Windows/Linux only; macOS dismisses correctly without it.

## Notes

- A `closedByPlugin` flag on each tracked notification keeps the `close` event handler from calling `onMute()` when the plugin itself closes the notification. On Windows the `close` event also fires when a toast merely moves into the action center, so this avoids a redundant reload/save on every notification.
- The map entry is removed as soon as the plugin closes a notification rather than waiting for the `close` event, which never fires for a notification that has already moved to the action center.

## Testing

`mise run pre-commit` passes (eslint, tsc, svelte-check, 232 jest tests). Verified on macOS only -- the Windows/Linux behavior of `timeoutType: "never"` has not been checked on real hardware.
