### PR TITLE
Let Dependabot sit on new releases before opening PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,23 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # Actions only support the ecosystem-wide `default-days` (there is no
+    # SemVer-aware cooldown for them), so hold every action update back long
+    # enough that a bad release is usually yanked or patched before it shows
+    # up here. Security updates ignore cooldown, so this doesn't delay those.
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
     open-pull-requests-limit: 5
+    # Only majors wait: they are the ones that need the ecosystem to catch up
+    # (see the `ignore` entries below for how often that bites here). Minor
+    # and patch updates keep GitHub's default 3-day cooldown.
+    cooldown:
+      semver-major-days: 14
     ignore:
       # obsidian declares an exact peer dependency on @codemirror/state
       # (currently 6.5.0), so newer @codemirror/* versions break npm install


### PR DESCRIPTION
Two major bumps arrived together this month (`actions/github-script` 7 -> 9 and `actions/stale` 9 -> 11), each skipping an intermediate major. With a monthly schedule that will keep happening, and it makes breaking changes harder to review one at a time.

- **github-actions**: `default-days: 14`. This ecosystem has no SemVer-aware cooldown, so it is all-or-nothing; 14 days across the board is fine for actions, which are on a monthly schedule anyway.
- **npm**: `semver-major-days: 14`, leaving minor/patch on GitHub's default 3-day cooldown.

Cooldown applies to version updates only -- security updates are never delayed by it.