### PR TITLE
Add an obsidian-e2e skill for automated testing against a live Obsidian

### DIFF
--- a/.claude/skills/obsidian-e2e/SKILL.md
+++ b/.claude/skills/obsidian-e2e/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: obsidian-e2e
+description: Drive a real, running Obsidian instance over the Chrome DevTools Protocol (CDP) to automatically test obsidian-reminder — evaluate JS inside the app, fire reminders on demand, and screenshot the window. Use this when the user wants automated end-to-end checks against a live Obsidian ("自動でテストして", "CDPで確認して", "obsidian-e2eで", "reminderを自動で発火させて確認して"), as opposed to manual-verify, which prepares a vault for a human to click through. Runs exclusively against the user's dedicated test vault — never against their personal or work vaults.
+---
+
+# obsidian-e2e: automated testing against a live Obsidian
+
+## Relationship to `manual-verify`
+
+`manual-verify` prepares a test vault (symlink, settings, fixture notes) and then
+hands the user a checklist to click through by hand. This skill instead drives that
+same running Obsidian over CDP so an agent can fire reminders, click UI, and read
+back internal state without a human in the loop.
+
+They are complementary, not interchangeable:
+
+- Things this skill **can** verify automatically: reminder firing timing, toast
+  contents, button clicks and their effect on the file, settings state,
+  `Reminders`/`ReminderNotifier` internal state.
+- Things only a **human** can verify (see "What cannot be automated" below): the
+  look and feel of macOS system notifications, whether a system notification click
+  actually does the right thing, and anything that depends on the user's macOS
+  notification style settings (Banners vs. Alerts, etc).
+
+For anything touching `src/plugin/` or `src/ui/`, prefer running both: this skill
+for the parts it can check unattended, `manual-verify` for the rest.
+
+## The absolute safety requirement
+
+**This machine typically has several vaults registered and multiple open at once.
+Only a vault explicitly and physically marked as safe for testing (see "The
+actual guard" below) may ever be touched. Every other vault — personal or work —
+must never be written to, and, per the incident below, not even read.**
+
+### The wrong-vault write incident (read this before changing any guard)
+
+Earlier in this skill's development, a guard was verified by actually calling
+`app.vault.adapter.write(...)` with `OBSIDIAN_TEST_VAULT_NAME` pointed at a real,
+non-test vault, on the reasoning that "the guard should reject this." **It did
+not.** The guard at the time only checked that the vault *name* in the CDP page
+title was unambiguous and matched what the in-page code re-read from
+`app.vault.getName()` — and a real vault's actual name is, by definition, a
+perfectly real, unambiguous, matching vault name. The write silently succeeded,
+creating a stray file in a real personal vault, which then had to be cleaned up.
+
+Two lessons are now load-bearing parts of the design, not just advice:
+
+1. **Matching a vault by name is not a safety guard — it is a routing
+   mechanism.** A name is just a string; anyone (human or agent) can type the name
+   of a real vault into an env var, on purpose or by typo, and a name-matching
+   guard will happily "correctly" route to it. Name/title matching (the
+   `" - <VAULT_NAME> - "` checks below) exists to prevent *ambiguity* (which window
+   is it?) and *staleness* (did the window change vaults?) — it does not and
+   cannot express *consent* ("is this vault okay to test against?").
+2. **Verifying that a guard rejects something must never use a destructive
+   operation to prove the point.** A non-zero exit code and a stderr message are
+   sufficient proof of rejection. If you need to convince yourself a guard works,
+   test it with a read-only expression (`return 1;`, `return app.vault.getName();`)
+   or — better, so that no real vault is touched at all, not even for a read — a
+   synthetic directory of your own that mimics a vault's `.obsidian/` layout.
+   Never call `write`/`delete`/`rename`/`process` against a vault you don't
+   already know is the test vault.
+
+### The actual guard: an opt-in marker file, not a name
+
+Because name matching cannot express consent, the real permission boundary is a
+marker file: **`<vault>/.obsidian/obsidian-e2e-allowed`**. A vault is only usable
+by these scripts if this file physically exists inside it. The dedicated test
+vault has one (see its contents for the rationale, copied below); no other vault
+may ever have one added.
+
+```
+This file marks this vault as safe for the obsidian-reminder repository's
+obsidian-e2e skill (.claude/skills/obsidian-e2e/). Its scripts write to and
+otherwise operate on any vault that has this marker, without asking again.
+
+Do NOT copy this file into another vault (any other personal or work vault).
+A vault with this file present WILL be rewritten by automated tests — files
+created, task lines edited, reminders fired.
+
+If this file is missing, the obsidian-e2e scripts refuse to run against the
+vault, even if OBSIDIAN_TEST_VAULT_NAME/OBSIDIAN_TEST_VAULT_PATH happen to
+point at it. This is the actual safety boundary — matching a vault by name
+alone is not enough, since a name can be typed (or mistyped) into an env var
+by anyone.
+```
+
+**Never copy this marker file into another vault**, and never add logic that
+creates it automatically for a vault the user hasn't explicitly prepared.
+
+### The full guard stack, per script
+
+Every script that can affect a vault (`obsidian-eval.mjs`, `reminder-fire.sh`)
+implements all of the following, independently (filesystem-side and, where
+applicable, page-side — see below for why both):
+
+1. **Required env vars, no hardcoded defaults.** `OBSIDIAN_TEST_VAULT_NAME` and
+   `OBSIDIAN_TEST_VAULT_PATH` must both be set, or the script exits immediately
+   with a usage error. An accidentally-run script with no environment configured
+   must do nothing.
+2. **Name/path agreement.** `basename(realpath(OBSIDIAN_TEST_VAULT_PATH))` must
+   equal `OBSIDIAN_TEST_VAULT_NAME`. This catches copy-paste mistakes where the two
+   env vars disagree about which vault is meant.
+3. **Marker file check, from the filesystem side.**
+   `OBSIDIAN_TEST_VAULT_PATH/.obsidian/obsidian-e2e-allowed` must exist. This is
+   checked with plain `fs`/`test -f`, before any CDP call is made — an unmarked
+   vault is rejected before the script even talks to Obsidian.
+4. **CDP target selection.** Among the CDP page targets, exactly one page's title
+   must contain `" - <VAULT_NAME> - "` (the substring Obsidian places between the
+   active note's title and `"Obsidian <version>"`). Zero matches or more than one
+   match both abort the run — see "Known limitations" for a caveat on this
+   substring match.
+5. **Re-check from inside the page.** The JS actually evaluated in the page is
+   wrapped so that, before any of your code runs, it re-reads
+   `app.vault.getName()` **and** re-checks
+   `await app.vault.adapter.exists(".obsidian/obsidian-e2e-allowed")` from inside
+   Obsidian's own JS context. Both must hold. This exists because steps 2–4 above
+   run in a separate `node`/`bash` process against a point-in-time snapshot (the
+   CDP target list, the filesystem); the vault shown in a given window could in
+   principle change between that snapshot and the code actually executing.
+
+`obsidian-shot.sh` is the one exception: it never writes into a vault (it only
+reads the on-screen window list and writes a screenshot file wherever you tell it
+to), so it does not check the marker file — but it still requires
+`OBSIDIAN_TEST_VAULT_NAME` and still enforces "exactly one match," cross-checked
+against both the OS window list and the CDP page list independently.
+
+`obsidian-launch.sh` doesn't touch any vault at all (it only starts/stops the
+Obsidian process and polls the CDP HTTP endpoint), so no vault guard applies to it.
+
+## Environment-specific configuration
+
+Exactly as in `manual-verify`: never hardcode vault paths or names in scripts,
+skill docs, or committed files. Read them from `CLAUDE.local.md` at the repository
+root (auto-loaded into context, gitignored). Expected entries: test vault path
+(`OBSIDIAN_TEST_VAULT_PATH`), and its `basename` doubles as
+`OBSIDIAN_TEST_VAULT_NAME`, plus the plugin symlink location (same entries
+`manual-verify` uses). If `CLAUDE.local.md` is missing this, ask the user and
+offer to record it.
+
+## Scripts
+
+All scripts live in `scripts/` and use only Node's built-ins (`fetch`,
+`WebSocket`, `fs`) plus macOS system tools (`osascript`, `screencapture`, `python3`
++ PyObjC's `Quartz`) — no `npm install` required, so they work in a worktree before
+`mise run main:init` has ever been run.
+
+### `obsidian-launch.sh [--restart]`
+
+Ensures Obsidian is running with `--remote-debugging-port=$OBSIDIAN_CDP_PORT`
+(default port `9333` — `9222` is often already taken by a running Chrome). If CDP
+is already reachable and belongs to Obsidian, it's a no-op (prints the open page
+titles and exits). Otherwise it quits any running Obsidian instance (Electron apps
+can't have `--remote-debugging-port` turned on after the fact) and relaunches it
+with the flag, then polls until CDP responds.
+
+Not vault-specific — it affects every open vault's window (all vaults reopen, no
+data loss, but any unsaved modal/dialog state in another vault's window is lost).
+It only actually restarts when required; running it opportunistically before other
+scripts is safe and usually a no-op.
+
+### `obsidian-eval.mjs`
+
+```
+# OBSIDIAN_TEST_VAULT_NAME / OBSIDIAN_TEST_VAULT_PATH come from CLAUDE.local.md —
+# export them once per shell session before using any of these scripts.
+export OBSIDIAN_TEST_VAULT_NAME=<test vault name>
+export OBSIDIAN_TEST_VAULT_PATH=<test vault path>
+
+node .claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs 'return app.vault.getName();'
+
+# or, for longer scripts:
+node .claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs --file /path/to/script.js
+```
+
+Evaluates JavaScript inside the matched Obsidian window as the body of an async
+function (`return`/`await` both work). Prints the result as JSON to stdout;
+exceptions go to stderr with a non-zero exit.
+
+Because production builds don't mangle property names (esbuild only does that with
+an explicit `mangleProps`, which this project's `esbuild.config.mjs` doesn't set),
+internal plugin state is directly reachable. Confirmed working as of this writing:
+
+- `app.plugins.plugins["obsidian-reminder-plugin"]` → `_reminders`, `settings`,
+  `ui`, etc.
+- `.ui.reminderNotifier.toastManager.toasts` → `Map` of currently-shown toasts,
+  keyed by `<file><title><time>`.
+- `.ui.reminderNotifier.systemNotifier.systemNotifications` → `Map` of tracked
+  system notifications. **This is how you detect that a system notification fired
+  even though you can't click it** (see "What cannot be automated").
+- `.ui.reminderNotifier.systemNotifier.isAvailable()` → whether system
+  notifications are usable on this platform.
+
+**This is refactor-fragile.** These paths reflect the `ReminderNotifier`/
+`SystemNotifier` split (PR #353). If a future refactor moves things around, this
+code will throw `TypeError: Cannot read properties of undefined`. When that
+happens, don't guess — run
+`node obsidian-eval.mjs 'return Object.keys(app.plugins.plugins["obsidian-reminder-plugin"]);'`
+(and drill in from there) to rediscover the actual structure, and update this file.
+
+### `reminder-fire.sh <note-path-relative-to-vault> <text-unique-to-the-line> [minutesAgo]`
+
+```
+# (OBSIDIAN_TEST_VAULT_NAME / OBSIDIAN_TEST_VAULT_PATH already exported — see above)
+.claude/skills/obsidian-e2e/scripts/reminder-fire.sh \
+  reminder-test/e2e-skill/smoke.md e2e-skill-smoke-task1 5
+```
+
+Rewrites the first `YYYY-MM-DD` or `YYYY-MM-DD HH:mm` date pattern on the first
+line containing the given text to `minutesAgo` minutes before now (default 2). A
+reminder past its time fires within about 5 seconds — there's no need to wait the
+"real" 3 minutes a fresh reminder would take. Because firing also clears mute
+state, the same fixture line can be re-fired indefinitely by calling this again
+(it'll pick a new, slightly different past timestamp each time).
+
+This edits the file directly via the filesystem (not through CDP/`app.vault`), so
+it carries its own copy of the filesystem-side guards (env vars, name/path
+agreement, marker file) plus a `realpath`-based check that the target note
+resolves inside the vault root — this is what blocks `../`-style escapes or a
+symlink pointing outside the vault. Obsidian must already be running and watching
+the vault for the external file change to be picked up.
+
+### `obsidian-shot.sh <output-path.png>`
+
+```
+# (OBSIDIAN_TEST_VAULT_NAME already exported — see above)
+.claude/skills/obsidian-e2e/scripts/obsidian-shot.sh /path/to/scratchpad/shot.png
+```
+
+Screenshots the on-screen Obsidian window belonging to the named vault.
+**Do not use `screencapture -R x,y,w,h`** — on Retina/multi-display setups its
+coordinate system doesn't match what window enumeration reports, and you silently
+get a blank, narrow sliver image instead of an error. **Do not try to use the
+Accessibility (AX) tree either** (`osascript`/System Events element enumeration) —
+even with `AXManualAccessibility` set, enumerating elements has been unreliable and
+prone to timing out in testing; drive the UI through CDP/DOM instead (see
+`obsidian-eval.mjs`), and use this script only for pixel screenshots.
+
+Window discovery goes through Quartz's `CGWindowListCopyWindowInfo` (via
+`python3` + PyObjC), matching `kCGWindowOwnerName == "Obsidian"` and a
+`kCGWindowName` containing `" - <VAULT_NAME> - "`, then
+`screencapture -x -o -l <windowID>`. Write the output somewhere outside any vault
+(the session scratchpad is the right place) — this script does not stop you from
+pointing the output path inside a vault, so don't.
+
+## What cannot be automated
+
+Be upfront about these with the user rather than trying to fake a check:
+
+- **Clicking macOS system notifications.** They're rendered by Electron's
+  `Notification` API, which lives outside the DOM entirely — CDP cannot see or
+  click them. You *can* detect that one was raised (see
+  `systemNotifier.systemNotifications` above), but not interact with it.
+- **How a system notification actually looks**, including anything that depends
+  on the user's System Settings → Notifications style (Banners vs. Alerts,
+  grouping, etc). This has to be eyeballed by a human.
+- **Subjective UI/UX judgment** — animation smoothness, whether a layout "looks
+  right." This skill can assert DOM state and pixel-diff screenshots at best; it
+  can't judge aesthetics.
+
+For these, hand off to `manual-verify`.
+
+## Typical workflow
+
+1. **Build** the checkout under test:
+   `mise exec -- npm run build` (run `mise run main:init` first in a worktree
+   that has no `node_modules` yet).
+2. **Point the vault's plugin symlink** at that checkout (same gotcha as
+   `manual-verify`: this is disruptive to whoever else might be using the
+   symlink, and Obsidian must not be actively writing `data.json` while you swap
+   it — quit Obsidian first if you're also touching settings).
+3. **Ensure Obsidian is up with CDP**: `obsidian-launch.sh`.
+4. **Fire** the reminder(s) you need: `reminder-fire.sh`.
+5. **Operate/verify** via `obsidian-eval.mjs` (click buttons, read state) and/or
+   `obsidian-shot.sh` (visual capture for the user to glance at, or for
+   comparison).
+6. **Clean up** (see below).
+
+## A concrete, actually-run verification example
+
+This exact sequence was run against the dedicated test vault while building this
+skill, using the fixture at `reminder-test/e2e-skill/smoke.md`
+(`- [ ] e2e-skill-smoke-task1 ⏰ 2026-08-01 10:00`):
+
+```
+$ reminder-fire.sh reminder-test/e2e-skill/smoke.md e2e-skill-smoke-task1 5
+2026-08-02 20:23
+```
+
+After a few seconds, confirm the toast actually appeared (reading internal state,
+not guessing):
+
+```js
+// via obsidian-eval.mjs
+const plugin = app.plugins.plugins["obsidian-reminder-plugin"];
+const toasts = [...plugin.ui.reminderNotifier.toastManager.toasts.keys()];
+return { toastKeys: toasts.filter(k => k.includes("e2e-skill-smoke-task1")) };
+// => { toastKeys: ["reminder-test/e2e-skill/smoke.mde2e-skill-smoke-task12026-08-02 20:23"] }
+```
+
+Then click "Done" on that toast's card and confirm the file changed:
+
+```js
+// via obsidian-eval.mjs
+const card = [...document.querySelectorAll(".reminder-toast-card")]
+  .find(c => c.querySelector(".reminder-title")?.textContent === "e2e-skill-smoke-task1");
+const btn = [...card.querySelectorAll("button")].find(b => b.textContent.trim() === "Done");
+btn.click();
+```
+
+The file went from `- [ ] e2e-skill-smoke-task1 ⏰ 2026-08-01 10:00` to
+`- [x] e2e-skill-smoke-task1 ⏰ 2026-08-02 20:23 ✅ 2026-08-02` — verified by reading
+the file back, not by assuming the click worked.
+
+The toast DOM shape used above: `.reminder-toast-card` is one toast; inside it,
+`.reminder-title`, `.reminder-file`, `button` (`×` / the note name / `Done` /
+`Mute`), and `select.later-select` for the Snooze options.
+
+## Cleanup
+
+- Restore the vault's plugin symlink to wherever it should point when you're done
+  (main checkout, typically — rebuild it first so the vault serves the merged
+  code).
+- If you ran `obsidian-launch.sh --restart` or it had to relaunch Obsidian, that's
+  already back to normal (it launches with the same `--remote-debugging-port` — if
+  you want CDP off again for normal use, quit and relaunch Obsidian without the
+  flag).
+- Test fixtures under `<vault>/reminder-test/` can stay for next time, same as
+  `manual-verify`.
+- Never remove the `.obsidian/obsidian-e2e-allowed` marker from the test vault as
+  part of routine cleanup — it's meant to persist.
+
+## Known limitations
+
+- **The `" - <VAULT_NAME> - "` title substring match isn't airtight.** If the
+  *active note's own title* happens to contain a hyphen-padded segment that matches
+  another vault's name (e.g. a note titled `"Report - otherVault - Draft"` open
+  inside the test vault), a script targeting `otherVault` could match the wrong
+  window. This is why the marker-file check is the real guard and the title match
+  is only used for disambiguating *which already-approved vault's window* to talk
+  to — never treat title matching alone as sufficient permission.
+- **Internal state access (`ui.reminderNotifier`, etc.) is refactor-fragile** by
+  nature — see the note under `obsidian-eval.mjs` above.
+- **Marker-file existence is checked at two different times** (filesystem-side
+  before any CDP call, and page-side inside the guarded expression) but there is
+  necessarily a small window between them where the marker could theoretically be
+  removed. This is an accepted, understood gap (same class of TOCTOU issue any
+  filesystem-then-network guard has) — not something to "fix" by adding more
+  checks; understand the two-phase check as strong-but-not-atomic.

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+// Evaluate JavaScript inside a running Obsidian window over the Chrome DevTools
+// Protocol (CDP), for exactly one, explicitly named and explicitly opted-in vault.
+//
+// Safety model (do not weaken — see "the wrong-vault write incident" in SKILL.md for why
+// each layer exists):
+//   1. The vault to target must be given via OBSIDIAN_TEST_VAULT_NAME AND
+//      OBSIDIAN_TEST_VAULT_PATH. There are no hardcoded defaults — either being
+//      unset is a hard error, so an accidental invocation does nothing rather
+//      than hitting the wrong vault. The two must agree: basename(realpath(PATH))
+//      must equal NAME.
+//   2. Marker file, checked from the filesystem side: OBSIDIAN_TEST_VAULT_PATH
+//      must contain .obsidian/obsidian-e2e-allowed. This is the real safety
+//      boundary. Matching a vault by *name* is not enough — a name is just a
+//      string anyone can type into an env var, correctly or by mistake, and
+//      would otherwise happily resolve to someone's real vault. The marker file
+//      is an explicit, physical, per-vault opt-in that has to be placed by a
+//      human who understands "scripts under this skill will rewrite whatever is
+//      in this vault."
+//   3. Among the CDP page targets, exactly one page's title must contain
+//      " - <VAULT_NAME> - " (the substring Obsidian puts between the active
+//      note's title and "Obsidian <version>" in its window/tab title). Zero
+//      matches or more than one match both abort the run.
+//   4. The code that actually runs in the page is wrapped so its first actions
+//      are to re-read app.vault.getName() from inside the page and compare it
+//      again to VAULT_NAME, AND re-check the marker file via
+//      app.vault.adapter.exists(".obsidian/obsidian-e2e-allowed") from inside
+//      the page itself. User code only executes if both hold. This guards
+//      against the CDP target list being stale (e.g. a vault was swapped into
+//      an existing window) between step 3 and the call actually landing, and
+//      against the marker file having been removed/renamed between step 2 and
+//      now.
+//
+// Only Node's built-in fetch/WebSocket/fs are used (Node >= 22), so this works
+// even in a worktree that has no node_modules yet.
+//
+// Usage:
+//   node obsidian-eval.mjs '<javascript>'
+//   node obsidian-eval.mjs --file path/to/script.js
+//
+// The JavaScript is treated as the body of an async function: `return <value>;`
+// sends a value back, and `await` works. The result is printed to stdout as JSON
+// (or bare text for a plain string result). Exceptions go to stderr with a
+// non-zero exit code.
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const MARKER_RELATIVE_PATH = ".obsidian/obsidian-e2e-allowed";
+
+function usageError(message) {
+  console.error(`error: ${message}`);
+  console.error("");
+  console.error("usage:");
+  console.error("  node obsidian-eval.mjs '<javascript>'");
+  console.error("  node obsidian-eval.mjs --file path/to/script.js");
+  console.error("");
+  console.error("required env: OBSIDIAN_TEST_VAULT_NAME, OBSIDIAN_TEST_VAULT_PATH");
+  console.error("optional env: OBSIDIAN_CDP_PORT (default 9333)");
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  if (argv.length === 0) {
+    usageError("missing JavaScript to evaluate");
+  }
+  if (argv[0] === "--file") {
+    const path = argv[1];
+    if (!path) {
+      usageError("--file requires a path argument");
+    }
+    return readFileSync(path, "utf8");
+  }
+  if (argv[0] === "-h" || argv[0] === "--help") {
+    usageError("help requested");
+  }
+  return argv[0];
+}
+
+async function main() {
+  const vault = process.env.OBSIDIAN_TEST_VAULT_NAME;
+  const vaultPath = process.env.OBSIDIAN_TEST_VAULT_PATH;
+  if (!vault || !vaultPath) {
+    usageError(
+      "OBSIDIAN_TEST_VAULT_NAME and OBSIDIAN_TEST_VAULT_PATH are both required " +
+        "(no defaults — this is intentional: an unset vault must never silently " +
+        "fall back to some vault).",
+    );
+  }
+  const port = process.env.OBSIDIAN_CDP_PORT || "9333";
+  const code = parseArgs(process.argv.slice(2));
+
+  // --- Safety guard 1: path and name must agree ------------------------------
+  let realVaultPath;
+  try {
+    realVaultPath = realpathSync(vaultPath);
+  } catch (e) {
+    console.error(`error: OBSIDIAN_TEST_VAULT_PATH does not resolve: ${e.message}`);
+    process.exit(3);
+  }
+  if (basename(realVaultPath) !== vault) {
+    console.error(
+      `refusing to run: basename(OBSIDIAN_TEST_VAULT_PATH) is ${JSON.stringify(
+        basename(realVaultPath),
+      )}, which does not match OBSIDIAN_TEST_VAULT_NAME ${JSON.stringify(vault)}.`,
+    );
+    process.exit(3);
+  }
+
+  // --- Safety guard 2: marker file, checked from the filesystem side --------
+  const markerPath = join(realVaultPath, MARKER_RELATIVE_PATH);
+  if (!existsSync(markerPath)) {
+    console.error(
+      `refusing to run: no marker file at ${markerPath}. ` +
+        "A vault is only usable by obsidian-e2e scripts if it explicitly opts in " +
+        `by containing ${MARKER_RELATIVE_PATH} (see SKILL.md). Matching by vault ` +
+        "name alone is not treated as consent.",
+    );
+    process.exit(3);
+  }
+
+  // --- Safety guard 3: exactly one matching CDP page target ------------------
+  let targets;
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+    targets = await res.json();
+  } catch (e) {
+    console.error(
+      `error: could not reach CDP endpoint at http://127.0.0.1:${port}/json/list (${e.message}). ` +
+        "Is Obsidian running with --remote-debugging-port? See obsidian-launch.sh.",
+    );
+    process.exit(4);
+  }
+
+  const needle = ` - ${vault} - `;
+  const pages = targets.filter(
+    (t) => t.type === "page" && typeof t.title === "string" && t.title.includes(needle),
+  );
+
+  if (pages.length !== 1) {
+    console.error(
+      `refusing to run: expected exactly 1 page target whose title contains ${JSON.stringify(
+        needle,
+      )}, found ${pages.length}.`,
+    );
+    const allPages = targets.filter((t) => t.type === "page");
+    if (allPages.length === 0) {
+      console.error("  (no page targets at all)");
+    } else {
+      console.error("  page titles seen:");
+      for (const t of allPages) {
+        console.error(`    - ${t.title}`);
+      }
+    }
+    process.exit(3);
+  }
+
+  const target = pages[0];
+
+  // --- Safety guard 4: re-check vault name AND marker file from inside the page
+  const guardedExpression = `(async () => {
+    const __vault = app.vault.getName();
+    if (__vault !== ${JSON.stringify(vault)}) {
+      throw new Error(
+        "obsidian-eval safety guard: expected vault " + ${JSON.stringify(vault)} +
+        " but this page reports vault " + __vault
+      );
+    }
+    const __allowed = await app.vault.adapter.exists(${JSON.stringify(MARKER_RELATIVE_PATH)});
+    if (!__allowed) {
+      throw new Error(
+        "obsidian-eval safety guard: marker file " + ${JSON.stringify(MARKER_RELATIVE_PATH)} +
+        " not found in this vault. Refusing to run user code."
+      );
+    }
+    return await (async () => {
+${code}
+    })();
+  })()`;
+
+  const value = await evaluateInPage(target.webSocketDebuggerUrl, guardedExpression);
+
+  if (value === undefined) {
+    console.log("(undefined)");
+  } else if (typeof value === "string") {
+    console.log(value);
+  } else {
+    console.log(JSON.stringify(value, null, 2));
+  }
+}
+
+function evaluateInPage(webSocketDebuggerUrl, expression) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(webSocketDebuggerUrl);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("timed out waiting for CDP response"));
+    }, 30_000);
+
+    ws.addEventListener("open", () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: "Runtime.evaluate",
+          params: {
+            expression,
+            awaitPromise: true,
+            returnByValue: true,
+          },
+        }),
+      );
+    });
+
+    ws.addEventListener("message", (event) => {
+      let msg;
+      try {
+        msg = JSON.parse(event.data.toString());
+      } catch {
+        return;
+      }
+      if (msg.id !== 1) return;
+      clearTimeout(timeout);
+      ws.close();
+
+      if (msg.error) {
+        reject(new Error(`CDP error: ${JSON.stringify(msg.error)}`));
+        return;
+      }
+      const result = msg.result;
+      if (result.exceptionDetails) {
+        reject(
+          new Error(
+            result.exceptionDetails.exception?.description ||
+              JSON.stringify(result.exceptionDetails),
+          ),
+        );
+        return;
+      }
+      resolve(result.result?.value);
+    });
+
+    ws.addEventListener("error", (event) => {
+      clearTimeout(timeout);
+      reject(new Error(`WebSocket error: ${event.message || "unknown"}`));
+    });
+  });
+}
+
+main().catch((e) => {
+  console.error("ERROR:", e.message);
+  process.exit(1);
+});

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-launch.sh
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-launch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Ensure Obsidian is running with remote debugging (CDP) enabled, so
+# obsidian-eval.mjs / obsidian-shot.sh / reminder-fire.sh have something to
+# talk to.
+#
+# This script is NOT vault-specific — it operates on the Obsidian *application*,
+# which on this machine reopens whatever vaults were open last time as separate
+# windows. It never reads or writes inside any vault; it only starts/stops the
+# app process and polls the CDP HTTP endpoint. The per-vault safety guards
+# (marker file, vault name match) live in the other scripts, which is where
+# they matter.
+#
+# Restarting Obsidian does not lose vault data (Obsidian saves on every edit),
+# but it does close whatever windows/dialogs/unsaved-modal-state existed, and
+# it affects every open vault's window, not just the test one. This script
+# only actually restarts when it has to (CDP not yet reachable, or the caller
+# passes --restart).
+#
+# Usage:
+#   obsidian-launch.sh          # ensure CDP is up; start/restart only if needed
+#   obsidian-launch.sh --restart  # force a quit+relaunch even if CDP already works
+#
+# Env:
+#   OBSIDIAN_CDP_PORT   default 9333 (9222 is often already taken by Chrome)
+
+set -euo pipefail
+
+PORT="${OBSIDIAN_CDP_PORT:-9333}"
+FORCE_RESTART=0
+if [[ "${1:-}" == "--restart" ]]; then
+  FORCE_RESTART=1
+fi
+
+cdp_version_json() {
+  curl -s --max-time 2 "http://127.0.0.1:${PORT}/json/version" 2>/dev/null || true
+}
+
+list_page_titles() {
+  curl -s --max-time 2 "http://127.0.0.1:${PORT}/json/list" 2>/dev/null \
+    | node -e '
+        let data = "";
+        process.stdin.on("data", (c) => (data += c));
+        process.stdin.on("end", () => {
+          try {
+            const targets = JSON.parse(data);
+            for (const t of targets) {
+              if (t.type === "page") console.log("  - " + t.title);
+            }
+          } catch {
+            // ignore
+          }
+        });
+      '
+}
+
+cdp_is_obsidian() {
+  # The /json/version User-Agent embeds a lowercase "obsidian/<version>" token
+  # (e.g. "... obsidian/1.12.7 Chrome/... Electron/..."), not "Obsidian" — match
+  # case-insensitively so this doesn't silently fail again.
+  local info="$1"
+  [[ "${info,,}" == *"obsidian/"* ]]
+}
+
+if [[ "$FORCE_RESTART" -eq 0 ]]; then
+  version_info="$(cdp_version_json)"
+  if [[ -n "$version_info" ]]; then
+    if cdp_is_obsidian "$version_info"; then
+      echo "Obsidian already reachable via CDP on port $PORT."
+      echo "Open page targets:"
+      list_page_titles
+      exit 0
+    else
+      echo "error: something is already listening on port $PORT via CDP, but it doesn't look like Obsidian." >&2
+      echo "  response: $version_info" >&2
+      echo "Pick a different OBSIDIAN_CDP_PORT (9222 is commonly used by Chrome)." >&2
+      exit 4
+    fi
+  fi
+fi
+
+# Nothing (usable) is listening on the port. If Obsidian is running without
+# debugging enabled (or --restart was requested), quit it first — you cannot
+# turn on --remote-debugging-port for an already-running process.
+if pgrep -x "Obsidian" > /dev/null 2>&1; then
+  echo "Quitting the running Obsidian instance (it isn't exposing CDP on port $PORT, or --restart was requested)..."
+  osascript -e 'tell application "Obsidian" to quit' > /dev/null 2>&1 || true
+  for _ in $(seq 1 30); do
+    if ! pgrep -x "Obsidian" > /dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+  if pgrep -x "Obsidian" > /dev/null 2>&1; then
+    echo "error: Obsidian did not quit within 15s. Quit it manually and re-run this script." >&2
+    exit 5
+  fi
+fi
+
+echo "Launching Obsidian with --remote-debugging-port=$PORT..."
+open -a Obsidian --args --remote-debugging-port="$PORT"
+
+echo "Waiting for CDP to become reachable..."
+for _ in $(seq 1 60); do
+  version_info="$(cdp_version_json)"
+  if [[ -n "$version_info" ]] && cdp_is_obsidian "$version_info"; then
+    echo "Obsidian is up, CDP reachable on port $PORT."
+    echo "Open page targets:"
+    list_page_titles
+    exit 0
+  fi
+  sleep 0.5
+done
+
+echo "error: CDP did not become reachable on port $PORT within 30s." >&2
+exit 6

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-shot.sh
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-shot.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Capture a screenshot of the Obsidian window for exactly one, explicitly
+# named vault.
+#
+# Why not `screencapture -R x,y,w,h`: on Retina / multi-display setups the
+# coordinate system screencapture -R expects doesn't line up with what
+# CGWindowListCopyWindowInfo reports, and you silently get a blank, narrow
+# sliver image instead of an error. Capturing by window ID
+# (`screencapture -x -o -l <id>`) is the only approach that has actually
+# worked in testing.
+#
+# Why not the Accessibility (AX) tree for locating the window: AXManualAccessibility
+# + System Events enumeration has been unreliable/timeout-prone here. Window
+# discovery instead goes through Quartz's CGWindowListCopyWindowInfo
+# (PyObjC), matching kCGWindowOwnerName == "Obsidian" and a kCGWindowName
+# containing " - <VAULT_NAME> - " (same title convention CDP page targets
+# use — see obsidian-eval.mjs).
+#
+# This script never writes into any vault: it only reads the on-screen window
+# list (OS-level, not vault content) and writes a PNG to the output path you
+# give it. It therefore does not check for the obsidian-e2e-allowed marker
+# file (that marker means "this vault's files may be rewritten by
+# automation," which doesn't apply here) — but it does still require the
+# vault name and enforces the same "exactly one match" rule as the other
+# scripts, cross-checked against the CDP page list as a second, independent
+# source of truth.
+#
+# Usage:
+#   obsidian-shot.sh <output-path.png>
+#
+# Env:
+#   OBSIDIAN_TEST_VAULT_NAME   required, no default
+#   OBSIDIAN_CDP_PORT          default 9333 (used only for the cross-check)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: obsidian-shot.sh <output-path.png>" >&2
+  echo "required env: OBSIDIAN_TEST_VAULT_NAME" >&2
+  exit 2
+fi
+OUTPUT_PATH="$1"
+
+: "${OBSIDIAN_TEST_VAULT_NAME:?error: OBSIDIAN_TEST_VAULT_NAME is required (no default)}"
+PORT="${OBSIDIAN_CDP_PORT:-9333}"
+
+# --- Guard A: exactly one on-screen Obsidian window matching the vault -----
+# (temporarily disable errexit: a non-zero exit here means "not exactly one
+# match," which we want to report with our own message/exit code below, not
+# let `set -e` kill the script mid-substitution before we get the chance)
+set +e
+WINDOW_ID="$(python3 - "$OBSIDIAN_TEST_VAULT_NAME" << 'PYEOF'
+import sys
+import Quartz
+
+vault = sys.argv[1]
+needle = f" - {vault} - "
+
+wins = Quartz.CGWindowListCopyWindowInfo(
+    Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID
+)
+matches = [
+    w for w in wins
+    if w.get("kCGWindowOwnerName") == "Obsidian" and needle in (w.get("kCGWindowName") or "")
+]
+
+if len(matches) != 1:
+    print(f"COUNT:{len(matches)}", file=sys.stderr)
+    for w in wins:
+        if w.get("kCGWindowOwnerName") == "Obsidian":
+            print(f"  - {w.get('kCGWindowName', '')!r}", file=sys.stderr)
+    sys.exit(1)
+
+print(matches[0]["kCGWindowNumber"])
+PYEOF
+)"
+STATUS=$?
+set -e
+if [[ $STATUS -ne 0 || -z "$WINDOW_ID" ]]; then
+  echo "refusing to run: expected exactly 1 on-screen Obsidian window titled with ' - $OBSIDIAN_TEST_VAULT_NAME - ', see counts/titles above." >&2
+  exit 3
+fi
+
+# --- Guard B: cross-check against the CDP page list (independent source) ---
+PAGE_COUNT="$(curl -s --max-time 2 "http://127.0.0.1:${PORT}/json/list" 2>/dev/null \
+  | node -e '
+      let data = "";
+      process.stdin.on("data", (c) => (data += c));
+      process.stdin.on("end", () => {
+        const vault = process.argv[1];
+        const needle = ` - ${vault} - `;
+        try {
+          const targets = JSON.parse(data);
+          const n = targets.filter(
+            (t) => t.type === "page" && typeof t.title === "string" && t.title.includes(needle),
+          ).length;
+          console.log(n);
+        } catch {
+          console.log(0);
+        }
+      });
+    ' "$OBSIDIAN_TEST_VAULT_NAME")"
+if [[ "$PAGE_COUNT" != "1" ]]; then
+  echo "refusing to run: window list found exactly 1 match, but the CDP page list found $PAGE_COUNT (expected 1). Refusing due to disagreement between the two sources." >&2
+  echo "(Is Obsidian running with --remote-debugging-port=$PORT? See obsidian-launch.sh.)" >&2
+  exit 3
+fi
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+screencapture -x -o -l "$WINDOW_ID" "$OUTPUT_PATH"
+echo "saved: $OUTPUT_PATH"

--- a/.claude/skills/obsidian-e2e/scripts/reminder-fire-rewrite.mjs
+++ b/.claude/skills/obsidian-e2e/scripts/reminder-fire-rewrite.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Pure text-rewrite helper for reminder-fire.sh. No vault/CDP knowledge lives
+// here on purpose: all the safety checks (env vars, realpath, marker file) are
+// done by reminder-fire.sh *before* this is ever invoked, so this file can stay
+// a small, easily-inspectable string transformation.
+//
+// Finds the first line in FILE containing MATCH_TEXT, and rewrites the first
+// "YYYY-MM-DD" or "YYYY-MM-DD HH:mm" date pattern on that line to MINUTES_AGO
+// minutes before now (same shape: keeps the time-of-day component only if the
+// original had one). This works across all three reminder formats (default
+// "(@...)", Tasks plugin "⏰ ...", Kanban) because it doesn't care about the
+// surrounding syntax — it only looks for the bare date/time text.
+//
+// Usage: node reminder-fire-rewrite.mjs <file> <matchText> <minutesAgo>
+// Prints the new date/time string that was written, on success.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const [, , file, matchText, minutesAgoRaw] = process.argv;
+if (!file || !matchText || !minutesAgoRaw) {
+  console.error("usage: reminder-fire-rewrite.mjs <file> <matchText> <minutesAgo>");
+  process.exit(2);
+}
+const minutesAgo = Number(minutesAgoRaw);
+if (!Number.isFinite(minutesAgo)) {
+  console.error(`error: minutesAgo must be a number, got ${JSON.stringify(minutesAgoRaw)}`);
+  process.exit(2);
+}
+
+const DATE_TIME_RE = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}/;
+const DATE_ONLY_RE = /\d{4}-\d{2}-\d{2}/;
+
+function pad(n) {
+  return String(n).padStart(2, "0");
+}
+
+const target = new Date(Date.now() - minutesAgo * 60_000);
+const withTime = `${target.getFullYear()}-${pad(target.getMonth() + 1)}-${pad(
+  target.getDate(),
+)} ${pad(target.getHours())}:${pad(target.getMinutes())}`;
+const dateOnly = withTime.slice(0, 10);
+
+const original = readFileSync(file, "utf8");
+const lines = original.split("\n");
+
+let matchedLineIndex = -1;
+for (let i = 0; i < lines.length; i++) {
+  if (lines[i].includes(matchText)) {
+    matchedLineIndex = i;
+    break;
+  }
+}
+if (matchedLineIndex === -1) {
+  console.error(`error: no line in ${file} contains ${JSON.stringify(matchText)}`);
+  process.exit(3);
+}
+
+const line = lines[matchedLineIndex];
+let newLine;
+let written;
+if (DATE_TIME_RE.test(line)) {
+  newLine = line.replace(DATE_TIME_RE, withTime);
+  written = withTime;
+} else if (DATE_ONLY_RE.test(line)) {
+  newLine = line.replace(DATE_ONLY_RE, dateOnly);
+  written = dateOnly;
+} else {
+  console.error(
+    `error: matched line has no YYYY-MM-DD date pattern to rewrite: ${JSON.stringify(line)}`,
+  );
+  process.exit(3);
+}
+
+lines[matchedLineIndex] = newLine;
+writeFileSync(file, lines.join("\n"));
+console.log(written);

--- a/.claude/skills/obsidian-e2e/scripts/reminder-fire.sh
+++ b/.claude/skills/obsidian-e2e/scripts/reminder-fire.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Rewrite the date/time on a reminder task line to a few minutes in the past, so
+# the plugin's notification-worker treats it as expired and fires within
+# seconds (no need to wait ~3 minutes for a real deadline). Because it also
+# clears mute state, the same fixture line can be reused across runs by simply
+# firing it again.
+#
+# This writes directly to a file inside the vault via the filesystem (not
+# through CDP), so it carries its own, filesystem-side copy of the safety
+# guards documented in obsidian-eval.mjs and SKILL.md:
+#   1. OBSIDIAN_TEST_VAULT_NAME and OBSIDIAN_TEST_VAULT_PATH are both required.
+#      No hardcoded defaults.
+#   2. basename(realpath(OBSIDIAN_TEST_VAULT_PATH)) must equal
+#      OBSIDIAN_TEST_VAULT_NAME.
+#   3. OBSIDIAN_TEST_VAULT_PATH/.obsidian/obsidian-e2e-allowed must exist. This
+#      marker file is the actual opt-in — matching the vault by name alone is
+#      not enough (see "the wrong-vault write incident" in SKILL.md).
+#   4. The target note path is realpath-normalized and must resolve to
+#      somewhere inside the (realpath-normalized) vault root. This blocks
+#      writes that escape the vault root via ../.. or a symlink.
+#
+# Usage:
+#   reminder-fire.sh <note-path-relative-to-vault> <text-unique-to-the-line> [minutesAgo]
+#
+# <note-path-relative-to-vault>  e.g. reminder-test/1-toast.md
+# <text-unique-to-the-line>      a substring that appears on exactly the task
+#                                 line you want to fire, e.g. the task title
+# [minutesAgo]                   how far in the past to set the date/time,
+#                                 default 2 (minutes)
+#
+# Required env:
+#   OBSIDIAN_TEST_VAULT_NAME
+#   OBSIDIAN_TEST_VAULT_PATH
+#
+# Note: this only rewrites the file on disk. Obsidian must be running and
+# watching the vault (see obsidian-launch.sh) for the file-change event and
+# the notification-worker's periodic check to actually pick it up and fire.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MARKER_RELATIVE_PATH=".obsidian/obsidian-e2e-allowed"
+
+usage() {
+  echo "usage: reminder-fire.sh <note-path-relative-to-vault> <text-unique-to-the-line> [minutesAgo]" >&2
+  echo "required env: OBSIDIAN_TEST_VAULT_NAME, OBSIDIAN_TEST_VAULT_PATH" >&2
+  exit 2
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+fi
+
+NOTE_RELATIVE_PATH="$1"
+MATCH_TEXT="$2"
+MINUTES_AGO="${3:-2}"
+
+: "${OBSIDIAN_TEST_VAULT_NAME:?error: OBSIDIAN_TEST_VAULT_NAME is required (no default)}"
+: "${OBSIDIAN_TEST_VAULT_PATH:?error: OBSIDIAN_TEST_VAULT_PATH is required (no default)}"
+
+# --- Safety guard 1: path and name must agree ------------------------------
+if ! REAL_VAULT_PATH="$(realpath "$OBSIDIAN_TEST_VAULT_PATH" 2>/dev/null)"; then
+  echo "error: OBSIDIAN_TEST_VAULT_PATH does not resolve: $OBSIDIAN_TEST_VAULT_PATH" >&2
+  exit 3
+fi
+VAULT_BASENAME="$(basename "$REAL_VAULT_PATH")"
+if [[ "$VAULT_BASENAME" != "$OBSIDIAN_TEST_VAULT_NAME" ]]; then
+  echo "refusing to run: basename(OBSIDIAN_TEST_VAULT_PATH) is '$VAULT_BASENAME', which does not match OBSIDIAN_TEST_VAULT_NAME '$OBSIDIAN_TEST_VAULT_NAME'." >&2
+  exit 3
+fi
+
+# --- Safety guard 2: marker file (the actual opt-in) -----------------------
+MARKER_PATH="$REAL_VAULT_PATH/$MARKER_RELATIVE_PATH"
+if [[ ! -f "$MARKER_PATH" ]]; then
+  echo "refusing to run: no marker file at $MARKER_PATH." >&2
+  echo "A vault is only usable by obsidian-e2e scripts if it explicitly opts in by containing $MARKER_RELATIVE_PATH (see SKILL.md)." >&2
+  exit 3
+fi
+
+# --- Safety guard 3: target note must resolve inside the vault root --------
+TARGET_PATH="$REAL_VAULT_PATH/$NOTE_RELATIVE_PATH"
+if [[ ! -f "$TARGET_PATH" ]]; then
+  echo "error: note not found: $TARGET_PATH (this script only edits existing notes; create the fixture note first)" >&2
+  exit 3
+fi
+if ! REAL_TARGET_PATH="$(realpath "$TARGET_PATH" 2>/dev/null)"; then
+  echo "error: could not resolve target note path: $TARGET_PATH" >&2
+  exit 3
+fi
+case "$REAL_TARGET_PATH" in
+  "$REAL_VAULT_PATH"/*) ;;
+  *)
+    echo "refusing to run: resolved note path '$REAL_TARGET_PATH' is outside the vault root '$REAL_VAULT_PATH'." >&2
+    exit 3
+    ;;
+esac
+
+# --- Do the rewrite ----------------------------------------------------------
+node "$SCRIPT_DIR/reminder-fire-rewrite.mjs" "$REAL_TARGET_PATH" "$MATCH_TEXT" "$MINUTES_AGO"


### PR DESCRIPTION
Automated tests only reach `src/model/`. Everything under `src/plugin/` and `src/ui/` has needed a human clicking through a vault, which is why `manual-verify` exists. This skill automates the part of that which can be automated.

## What it does

Starts Obsidian with `--remote-debugging-port`, then evaluates JavaScript inside the running app over the Chrome DevTools Protocol. That's enough to fire reminders on demand, click the toast/modal buttons, and read back both the resulting file contents and the plugin's own internal state -- unattended.

| Script | Purpose |
| --- | --- |
| `obsidian-eval.mjs` | Evaluate JS inside the Obsidian window for one opted-in vault |
| `obsidian-launch.sh` | Start/restart Obsidian with remote debugging, poll until CDP answers |
| `obsidian-shot.sh` | Screenshot a single vault's window |
| `reminder-fire.sh` + `reminder-fire-rewrite.mjs` | Rewrite a task line's date into the past so the reminder fires within seconds |

Node built-ins only (`fetch` / `WebSocket`, Node >= 22), so the scripts work in a worktree that hasn't run `npm install`.

## It does not replace `manual-verify`

macOS system notifications are drawn by the OS, outside the DOM, so **clicking one cannot be automated**. What *can* be checked automatically is that one was shown, by reading `SystemNotifier`'s tracking map. Look and feel, and anything depending on the user's macOS notification style, still need a human. The two skills are meant to run together, and SKILL.md says so up front.

## The safety model is the part worth reviewing

A vault is eligible only if it physically contains `.obsidian/obsidian-e2e-allowed`. Matching by vault *name* is treated as routing, not as consent -- a name is just a string that can be typed, or mistyped, into an environment variable.

That distinction isn't theoretical. While building this, a guard that only compared vault names let a write through to a real, non-test vault, because the name it was handed was genuine and unambiguous. SKILL.md records the incident and the two lessons it produced:

1. Name matching prevents *ambiguity* and *staleness*; it cannot express *consent*.
2. Verifying that a guard rejects something must never use a destructive operation to prove it. A non-zero exit code is sufficient proof.

The marker is checked twice: from the filesystem before any CDP call is made, and again from inside the page itself (`app.vault.adapter.exists(...)`) before any caller-supplied code runs. The second check exists because the first one operates on a point-in-time snapshot.

## Verified

Guard rejection paths, all tested against synthetic directories rather than real vaults:

| Case | Result |
| --- | --- |
| Env vars unset | exit 2, usage error |
| Marker file absent | exit 3, refuses before touching CDP |
| Name/path disagree | exit 3 |
| Correct vault name but no marker | exit 3 -- name alone is not enough |

Full positive path against the test vault: fire a reminder → confirm the toast appears in `toastManager.toasts` → click `Done` over CDP → confirm the file changed from `- [ ] ...` to `- [x] ... ✅ <date>`. That transcript is the worked example in SKILL.md.

No environment-specific values are committed: `grep -rniE "/Users/|<personal vault names>" .claude/skills/obsidian-e2e/` returns nothing. Paths come from `CLAUDE.local.md`, same as `manual-verify`.