### PR TITLE
Stop the reminder popup reappearing over the pause-all duration chooser

### DIFF
--- a/src/plugin/dnd.ts
+++ b/src/plugin/dnd.ts
@@ -28,8 +28,20 @@ export function resumeNotifications(plugin: ReminderPlugin): void {
   new Notice("Reminder notifications resumed");
 }
 
-export function showPauseDurationChooser(plugin: ReminderPlugin): void {
-  new DndDurationModal(plugin.app, plugin.settings.laters.value, (later) => {
-    pauseNotifications(plugin, later);
-  }).open();
+export function showPauseDurationChooser(
+  plugin: ReminderPlugin,
+  // Invoked once the chooser modal closes, whether the user picked a
+  // duration or dismissed it without choosing one. Optional because most
+  // callers (the command palette entries, the status bar) don't need to
+  // react to the chooser closing.
+  onClose?: () => void,
+): void {
+  new DndDurationModal(
+    plugin.app,
+    plugin.settings.laters.value,
+    (later) => {
+      pauseNotifications(plugin, later);
+    },
+    onClose,
+  ).open();
 }

--- a/src/plugin/ui/dnd-duration-chooser.ts
+++ b/src/plugin/ui/dnd-duration-chooser.ts
@@ -11,6 +11,11 @@ export class DndDurationModal extends SuggestModal<Later> {
     app: App,
     private laters: Array<Later>,
     private onSelect: (later: Later) => void,
+    // Called once the modal closes, whether the user picked a duration or
+    // dismissed it (e.g. Escape / clicking outside). Callers that need to
+    // know "the chooser is gone now" (as opposed to "a duration was picked")
+    // should use this rather than piggybacking on `onSelect`.
+    private onCloseCallback?: () => void,
   ) {
     super(app);
     this.setPlaceholder("Pause reminder notifications for...");
@@ -28,5 +33,9 @@ export class DndDurationModal extends SuggestModal<Later> {
 
   onChooseSuggestion(later: Later) {
     this.onSelect(later);
+  }
+
+  override onClose() {
+    this.onCloseCallback?.();
   }
 }

--- a/src/plugin/ui/index.ts
+++ b/src/plugin/ui/index.ts
@@ -263,8 +263,28 @@ export class ReminderPluginUI {
         // Unlike Mute, this must not leave this specific reminder muted:
         // pausing suppresses notifications globally without touching
         // individual reminders, so it re-fires once the pause ends.
-        reminder.muteNotification = false;
-        showPauseDurationChooser(this.plugin);
+        //
+        // However, we must NOT clear the mute flag right here. The duration
+        // chooser (`showPauseDurationChooser`) is opened but DND isn't set
+        // yet -- that only happens once the user actually picks a duration
+        // (see `pauseNotifications()` in `plugin/dnd.ts`). If we cleared
+        // `muteNotification` immediately, this reminder would be
+        // unprotected for however long the chooser stays open: the next
+        // `NotificationWorker` tick (every `reminderCheckIntervalSec`,
+        // default 5s) would see an expired, unmuted reminder with no DND in
+        // effect and pop the same reminder's modal again right on top of
+        // the still-open chooser. So keep `muteNotification` at the `true`
+        // it was set to when this reminder was displayed (top of
+        // `showReminder()`), and only flip it back to `false` in the
+        // chooser's `onClose` callback below, once the chooser is gone --
+        // by then either DND is active (chooser closed via a selected
+        // duration) or the user cancelled and expects normal re-notification
+        // on the next tick. Do not "simplify" this back to an immediate
+        // `reminder.muteNotification = false` without re-reading this
+        // comment; that is the exact regression this code fixes.
+        showPauseDurationChooser(this.plugin, () => {
+          reminder.muteNotification = false;
+        });
       },
       muteAll: () => {
         console.debug("Mute all reminders");


### PR DESCRIPTION
Stacked on #353 (base is that branch, so this diff stays small; it retargets to master once #353 merges). The bug itself is **not** from #353 — it exists on master too. `notification-worker.ts`, `dnd.ts`, and `dnd-duration-chooser.ts` are untouched by that PR, and the body of `pauseAll` is unchanged there.

## The bug

Click `Pause all notifications…` in a reminder popup, and while you're still deciding which duration to pick, the very reminder you're trying to silence pops up again on top of the chooser.

Sequence:

1. `pauseAll` sets `reminder.muteNotification = false` and opens the duration chooser.
2. Do-not-disturb is **not** set yet — `pauseNotifications()` only runs once a duration is actually chosen.
3. Five seconds later (`reminderCheckIntervalSec`), `NotificationWorker` ticks.
4. It sees an expired, unmuted reminder with no DND in effect, and calls `showReminder()` again.

Measured with the `obsidian-e2e` skill, 12 s after clicking, chooser still open:

```
{ muted: true, beingDisplayed: true,
  openModals: ["(duration chooser)", "t6-pauseall"],   ← two modals stacked
  dnd: null }
```

## The fix

Clearing the mute flag is right — a paused reminder must notify again once the pause ends. Doing it *at click time* is what's wrong: it leaves the reminder unprotected for as long as the chooser is open.

So the clear is deferred until the chooser closes:

- `DndDurationModal` takes an optional close callback and overrides `onClose()`. It fires for both outcomes — a duration was picked, or the modal was dismissed.
- `showPauseDurationChooser(plugin, onClose?)` forwards it. Optional, so the command-palette callers are unaffected.
- `pauseAll` no longer touches `muteNotification` up front; it stays at the `true` that `showReminder()` set, and the callback clears it once the chooser is gone.

Both paths end up correct:

- **Duration picked** → DND is already active by the time `onClose` runs, so clearing the flag is safe; the reminder notifies again when the pause ends, as before.
- **Cancelled** → no DND, flag cleared, next tick re-notifies. Also as before.

The `pauseAll` comment now spells out why the deferral is load-bearing, since "just set it to false here" is the obvious-looking simplification that reintroduces this.

## Verified on a live Obsidian

Via the `obsidian-e2e` skill (#354), against the test vault:

| Scenario | Result |
| --- | --- |
| Chooser left open 15 s (3 ticks) | Only the chooser is open. No re-show. `muted` stays `true` |
| Cancel with Escape | `muted` → `false`, `dndUntil` stays null, next tick re-notifies |
| Pick "In 30 minutes" | `dndUntil` set 30 min out, `muted` → `false`, no popup while DND holds |

Reproduced the original bug first on the pre-fix build, so the "after" numbers mean something.

`mise run pre-commit` passes: 282 tests, 0 lint/tsc/svelte-check errors.

## Noticed while testing, not fixed here

With `notificationPopupStyle: "modal"` and many expired unmuted reminders at once, `NotificationWorker`'s display loop waits on each reminder's `beingDisplayed` in turn. If one of those modals is closed in a way that skips `onClose()`, the flag stays set and the loop blocks — `intervalTaskRunning` then makes every later tick a no-op, so notifications stop entirely until reload. Only reachable when something closes a modal out from under Obsidian, which is why it surfaced under automation rather than normal use. Worth a separate look.