### PR TITLE
Add an opt-in "Re-notify muted reminders on startup" setting

### DIFF
--- a/docs/src/guide/notification.md
+++ b/docs/src/guide/notification.md
@@ -82,6 +82,7 @@ A muted reminder is remembered across Obsidian restarts, so it stays muted even 
 A muted reminder becomes active again if you:
 - click it in [reminder list view](/guide/list-reminders.html), which opens the reminder popup again so you can mark it done or snooze it
 - change the reminder's date/time in the markdown
+- turn on [Re-notify muted reminders on startup](/setting/#re-notify-muted-reminders-on-startup), which clears every mute flag the next time Obsidian starts
 
 ## Muting all reminders at once
 

--- a/docs/src/setting/README.md
+++ b/docs/src/setting/README.md
@@ -41,6 +41,18 @@ Show reminder popups and system notifications when a reminder is due.
   - OFF: Reminder popups/system notifications are suppressed. The [reminder list view](/guide/list-reminders.html) keeps updating, and expired reminders still move to the [Overdue section](/guide/list-reminders.html#overdue-reminders).
 - Default: ON
 
+### Re-notify muted reminders on startup
+
+Clear every [muted](/guide/notification.html#mute-notification) reminder when Obsidian starts, so overdue reminders you muted in an earlier session notify you again.
+
+- Type: `boolean`
+- Values:
+  - ON: All mute flags are dropped on startup. Every overdue reminder is notified again, one after another. Muting is not distinguished by how it happened, so reminders muted via [Mute all current reminders](/guide/notification.html#muting-all-reminders-at-once) are cleared too.
+  - OFF: Muted reminders stay muted across restarts (default)
+- Default: OFF
+
+Turning this on takes effect at the next startup; it does not unmute anything right away.
+
 ### Reminder popup style
 
 Choose how the [builtin notification popup](/guide/notification.html#builtin-notification-modal) is presented.

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
     "testMatch": [
       "**/*.test.ts"
     ],
+    "moduleNameMapper": {
+      "^(\\.{1,2}/.*)\\.js$": "$1",
+      "^obsidian$": "<rootDir>/src/test/obsidian-mock.ts",
+      "\\.css$": "<rootDir>/src/test/style-mock.ts"
+    },
     "preset": "ts-jest/presets/default-esm"
   },
   "prettier": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ export default class ReminderPlugin extends Plugin {
         this.ui.reload(true);
       },
       () => this.settings.excludedPaths.value,
+      () => this.data.loaded,
     );
     this._notificationWorker = new NotificationWorker({
       registerInterval: (id) => this.registerInterval(id),

--- a/src/plugin/data.test.ts
+++ b/src/plugin/data.test.ts
@@ -1,0 +1,96 @@
+import { Reminders } from "model/reminder";
+import { PluginData } from "./data";
+import type { DataStore } from "./data";
+
+function createStore(data: unknown): DataStore {
+  return {
+    loadData: async () => data,
+    saveData: async () => {},
+  };
+}
+
+function savedData(settings: Record<string, unknown> = {}) {
+  return {
+    scanned: true,
+    settings,
+    reminders: {
+      "file.md": [
+        { title: "Muted", time: "2021-09-08", rowNumber: 0, muted: true },
+        { title: "Not muted", time: "2021-09-09", rowNumber: 1, muted: false },
+      ],
+    },
+  };
+}
+
+function mutedByTitle(reminders: Reminders): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  for (const reminder of reminders.reminders) {
+    result[reminder.title] = reminder.muteNotification;
+  }
+  return result;
+}
+
+describe("PluginData", (): void => {
+  test("restores persisted mute flags by default", async (): Promise<void> => {
+    const reminders = new Reminders(() => {});
+    const data = new PluginData(createStore(savedData()), reminders);
+
+    await data.load();
+
+    expect(data.settings.reNotifyMutedOnStartup.value).toBe(false);
+    expect(mutedByTitle(reminders)).toStrictEqual({
+      Muted: true,
+      "Not muted": false,
+    });
+  });
+
+  test("drops persisted mute flags when re-notification on startup is enabled", async (): Promise<void> => {
+    const reminders = new Reminders(() => {});
+    const data = new PluginData(
+      createStore(savedData({ reNotifyMutedOnStartup: true })),
+      reminders,
+    );
+
+    await data.load();
+
+    expect(data.settings.reNotifyMutedOnStartup.value).toBe(true);
+    expect(mutedByTitle(reminders)).toStrictEqual({
+      Muted: false,
+      "Not muted": false,
+    });
+  });
+
+  test("resolves `loaded` once load() has finished", async (): Promise<void> => {
+    const reminders = new Reminders(() => {});
+    const data = new PluginData(createStore(savedData()), reminders);
+    let resolved = false;
+    void data.loaded.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await data.load();
+    await data.loaded;
+
+    expect(resolved).toBe(true);
+  });
+
+  test("resolves `loaded` even when loading fails", async (): Promise<void> => {
+    const reminders = new Reminders(() => {});
+    const data = new PluginData(
+      {
+        loadData: async () => {
+          throw new Error("boom");
+        },
+        saveData: async () => {},
+      },
+      reminders,
+    );
+
+    await expect(data.load()).rejects.toThrow("boom");
+
+    await expect(data.loaded).resolves.toBeUndefined();
+  });
+});

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -109,6 +109,12 @@ export class PluginData {
       setting.load(data.settings);
     });
 
+    // Settings are restored just above, so the toggle already holds the
+    // persisted value here. Dropping the mute flags at restore time (rather
+    // than unmuting later) means a subsequent `Reminders.replaceFile()` has
+    // nothing to carry over.
+    const restoreMuted = !this.settings.reNotifyMutedOnStartup.value;
+
     const remindersData = data.reminders;
     if (remindersData) {
       Object.keys(remindersData).forEach((filePath) => {
@@ -126,7 +132,7 @@ export class PluginData {
               d.rowNumber,
               false,
             );
-            reminder.muteNotification = d.muted ?? false;
+            reminder.muteNotification = restoreMuted && (d.muted ?? false);
             return reminder;
           }),
         );

--- a/src/plugin/data.ts
+++ b/src/plugin/data.ts
@@ -24,6 +24,17 @@ export interface DataStore {
 
 export class PluginData {
   private restoring = true;
+  private resolveLoaded: () => void = () => {};
+  /**
+   * Resolves once the first `load()` has finished (or failed). Anything that
+   * reparses the whole vault has to wait for this, because scanning before
+   * the persisted settings and reminders are restored produces reminders
+   * parsed with default settings — and `Reminders.replaceFile()` would then
+   * carry the restored mute flags over onto them.
+   */
+  readonly loaded: Promise<void> = new Promise<void>((resolve) => {
+    this.resolveLoaded = resolve;
+  });
   changed: boolean = false;
   public scanned: Reference<boolean> = new Reference(false);
   public debug: Reference<boolean> = new Reference(false);
@@ -60,6 +71,16 @@ export class PluginData {
   }
 
   async load() {
+    try {
+      await this.doLoad();
+    } finally {
+      // Resolve even when loading failed, so that a scan waiting on
+      // `loaded` isn't blocked forever.
+      this.resolveLoaded();
+    }
+  }
+
+  private async doLoad() {
     console.debug("Load reminder plugin data");
     // `loadData()` returns data of unknown shape (it's whatever was
     // previously passed to `saveData()`), so this cast is a minimal, trusted

--- a/src/plugin/filesystem.ts
+++ b/src/plugin/filesystem.ts
@@ -10,6 +10,7 @@ export class ReminderPluginFileSystem {
     private reminders: Reminders,
     private onRemindersChanged: () => void,
     private excludedPaths: () => Array<string>,
+    private dataLoaded: () => Promise<void>,
   ) {}
 
   onload(plugin: ReminderPlugin) {
@@ -74,6 +75,15 @@ export class ReminderPluginFileSystem {
   }
 
   async reloadRemindersInAllFiles() {
+    // A full rescan can be requested before `PluginData.load()` has restored
+    // the persisted state: the `Scan reminders` command is available as soon
+    // as the plugin registers its commands, and the notification worker runs
+    // its initial scan on its first tick. Parsing every file before the
+    // settings are restored would use the default reminder formats and
+    // excluded paths, and the reminders `load()` restores afterwards would
+    // undo the `clear()` below (`Reminders.replaceFile()` carries the
+    // restored mute flags over onto freshly parsed reminders).
+    await this.dataLoaded();
     console.debug("Reload all files and collect reminders");
     this.reminders.clear();
     for (const file of this.vault.getMarkdownFiles()) {

--- a/src/plugin/settings/index.ts
+++ b/src/plugin/settings/index.ts
@@ -32,6 +32,7 @@ export class Settings {
   reminderTime: SettingModel<string, Time>;
   reminderTimeStep: SettingModel<number, number>;
   enableNotification: SettingModel<boolean, boolean>;
+  reNotifyMutedOnStartup: SettingModel<boolean, boolean>;
   notificationPopupStyle: SettingModel<string, string>;
   openNoteOnReminderClick: SettingModel<boolean, boolean>;
   useSystemNotification: SettingModel<boolean, boolean>;
@@ -93,6 +94,18 @@ export class Settings {
         "If disabled, reminder popups and system notifications are not shown. The reminder list view keeps working.",
       )
       .toggle(true)
+      .build(new RawSerde());
+
+    this.reNotifyMutedOnStartup = this.settings
+      .newSettingBuilder()
+      .key("reNotifyMutedOnStartup")
+      .name("Re-notify muted reminders on startup")
+      .desc(
+        "When enabled, reminders you previously muted are notified again the next time Obsidian starts. " +
+          "Useful if you rely on startup notifications to review overdue reminders. " +
+          'If many reminders are overdue, they are shown one after another — use the "Mute all current reminders" command to silence them again.',
+      )
+      .toggle(false)
       .build(new RawSerde());
 
     this.notificationPopupStyle = this.settings
@@ -479,6 +492,7 @@ export class Settings {
         this.reminderTimeStep,
         this.laters,
         this.enableNotification,
+        this.reNotifyMutedOnStartup,
         this.notificationPopupStyle,
         this.openNoteOnReminderClick,
         this.useSystemNotification,

--- a/src/test/obsidian-mock.ts
+++ b/src/test/obsidian-mock.ts
@@ -1,0 +1,16 @@
+/**
+ * Runtime stand-in for the `obsidian` module under jest.
+ *
+ * The `obsidian` npm package only ships type definitions (`"main": ""`), so
+ * anything that imports it cannot be loaded by jest at all. Most of the
+ * plugin sidesteps this by keeping its testable logic free of `obsidian`
+ * imports, but `plugin/settings/helper.ts` needs the real `Setting` UI class
+ * and is pulled in transitively by `plugin/data.ts`.
+ *
+ * Only the classes reachable at import time are declared here, as empty
+ * classes: no test constructs them, they just have to exist so the module
+ * graph loads. Add to this file when a test needs another export — and give
+ * it real behavior only if the test actually depends on it.
+ */
+export class Setting {}
+export class AbstractTextComponent {}

--- a/src/test/style-mock.ts
+++ b/src/test/style-mock.ts
@@ -1,0 +1,6 @@
+/**
+ * Runtime stand-in for `*.css` imports under jest. esbuild turns those into
+ * injected stylesheets at build time; in tests they carry no behavior, so the
+ * module just needs to load.
+ */
+export default {};


### PR DESCRIPTION
Closes #356.

## Background

The reporter upgraded from 1.1.21 to 1.4.1 and found that overdue reminders no longer notify on startup. This is not a regression: 1.2.2 (a75ff14, issue #183) started persisting mute state to `data.json`. Before that, mute lived only in memory, so every restart restored all reminders unmuted and every overdue one notified again. The reporter had been relying on that.

The behavior is intended, so this keeps the current default and adds an opt-in way back.

## Changes

**1. `fix: wait for plugin data before rescanning all files`**

A full rescan could run before `PluginData.load()` finished restoring state, because `load()` is awaited inside `onLayoutReady()` while the commands are already registered. Callers at risk: the `Scan reminders` command, `Convert reminder time format`, and the notification worker's initial scan.

When that happened, every file was parsed with default reminder formats and excluded paths, and the reminders restored afterwards undid the scan's `clear()` — `Reminders.replaceFile()` carries restored mute flags over onto freshly parsed reminders.

Before — a scan can win the race against `load()`:

```mermaid
sequenceDiagram
    participant W as NotificationWorker /<br/>Scan command
    participant FS as ReminderPluginFileSystem
    participant R as Reminders
    participant D as PluginData

    Note over D: onLayoutReady() starts<br/>await data.load()
    W->>FS: reloadRemindersInAllFiles()
    FS->>R: clear()
    FS->>R: parse every file<br/>(default formats & excluded paths)
    D-->>R: restore persisted reminders
    Note over R: replaceFile() carries restored<br/>mute flags onto fresh reminders,<br/>undoing the clear()
```

After — the scan waits on the `loaded` promise:

```mermaid
sequenceDiagram
    participant W as NotificationWorker /<br/>Scan command
    participant FS as ReminderPluginFileSystem
    participant R as Reminders
    participant D as PluginData

    W->>FS: reloadRemindersInAllFiles()
    FS->>D: await loaded
    Note over FS: blocked
    D->>D: load() restores settings + reminders
    D-->>R: restore persisted reminders
    D--)FS: loaded resolves<br/>(also on failure, so it never hangs)
    FS->>R: clear()
    FS->>R: parse every file<br/>(restored formats & excluded paths)
```

`PluginData` now exposes a `loaded` promise that resolves once the first `load()` settles (including on failure, so a scan is never blocked forever), and `reloadRemindersInAllFiles()` awaits it. `load()` never triggers a scan, so there is no deadlock.

**2. `feat: add "Re-notify muted reminders on startup" setting`**

New toggle, off by default, in Notifications right after `Enable reminder notifications`. When on, `PluginData.load()` drops every persisted mute flag, so all overdue reminders notify again at the next startup.

The flag is cleared at restore time rather than unmuted afterwards, so a later `Reminders.replaceFile()` has nothing to carry over.

Deliberate scope decisions:

- No new command. Setting only.
- Mute origin is not distinguished — reminders muted via `Mute all current reminders` are cleared too. `muteNotification` stays a plain boolean.
- No cap on how many are shown. They appear one after another, which is what 1.1.21 did.
- Turning the setting on does nothing immediately; it takes effect at the next startup.
- Saving while the setting is on writes `muted: false` to disk, so the previous mute history is lost. Accepted.

## Testing

New `src/plugin/data.test.ts` covers restore with the setting off/on, plus the `loaded` promise resolving on success and on failure.

Testing `PluginData` requires the `obsidian` module to be loadable, and it isn't — the npm package ships types only (`"main": ""`). Jest now maps `obsidian` and `*.css` imports to stubs under `src/test/`. This is new test infrastructure: `.claude/rules/testing.md` currently says there is no obsidian mock and that code importing `obsidian` shouldn't be unit-tested. That rule is now out of date; updating it is left out of this PR.

Full suite: 286 tests, 20 suites, all passing. `npm run lint` (eslint + tsc + svelte-check) clean.

## Verified in a live Obsidian (via CDP)

- Setting off (default): a muted overdue reminder stays muted across a restart, no toast.
- Setting on: the same muted overdue reminder shows its toast again after a restart.
- Setting on + `Mute all current reminders`: both muted reminders show again after a restart.
- Commit 1's gate: with the data-loaded promise held pending, `reloadRemindersInAllFiles()` stays pending and does not clear the reminder store; it completes once the promise resolves.

Not verified automatically: the production race itself (a scan issued in the window before `data.load()` resolves) can't be hit deterministically over CDP, and the settings tab screenshot couldn't be taken because Obsidian 1.13 opens settings in a separate window.

## Follow-up found while testing (not fixed here)

On a vault with no `data.json` yet, `PluginData.load()` returns early at `if (!data)` and never clears `restoring`. Every setting change is then treated as part of restore, so `TAG_RESCAN` settings don't trigger a rescan until the next restart. This predates this branch.
