### PR TITLE
Make obsidian-e2e survive the situations that actually broke it

### DIFF
--- a/.claude/skills/obsidian-e2e/SKILL.md
+++ b/.claude/skills/obsidian-e2e/SKILL.md
@@ -105,11 +105,14 @@ applicable, page-side — see below for why both):
    `OBSIDIAN_TEST_VAULT_PATH/.obsidian/obsidian-e2e-allowed` must exist. This is
    checked with plain `fs`/`test -f`, before any CDP call is made — an unmarked
    vault is rejected before the script even talks to Obsidian.
-4. **CDP target selection.** Among the CDP page targets, exactly one page's title
-   must contain `" - <VAULT_NAME> - "` (the substring Obsidian places between the
-   active note's title and `"Obsidian <version>"`). Zero matches or more than one
-   match both abort the run — see "Known limitations" for a caveat on this
-   substring match.
+4. **CDP target selection.** Among the CDP page targets, the pages whose titles
+   belong to `<VAULT_NAME>` are collected (two title shapes — see "Known
+   limitations"), and exactly one must survive. Zero aborts the run. More than
+   one is legitimate (settings window, popped-out notes), so the candidates are
+   classified by a fixed, read-only DOM probe that runs behind the very same
+   guard as user code, and `--window` picks one; if that still doesn't leave
+   exactly one, the run aborts. A candidate that fails the probe is never used —
+   failing it means the page could not prove which vault it belongs to.
 5. **Re-check from inside the page.** The JS actually evaluated in the page is
    wrapped so that, before any of your code runs, it re-reads
    `app.vault.getName()` **and** re-checks
@@ -119,14 +122,21 @@ applicable, page-side — see below for why both):
    CDP target list, the filesystem); the vault shown in a given window could in
    principle change between that snapshot and the code actually executing.
 
+`obsidian-wait.sh` is a polling loop around `obsidian-eval.mjs`, so it inherits
+every guard above rather than implementing its own.
+
 `obsidian-shot.sh` is the one exception: it never writes into a vault (it only
 reads the on-screen window list and writes a screenshot file wherever you tell it
 to), so it does not check the marker file — but it still requires
-`OBSIDIAN_TEST_VAULT_NAME` and still enforces "exactly one match," cross-checked
+`OBSIDIAN_TEST_VAULT_NAME` and still narrows to exactly one window, cross-checked
 against both the OS window list and the CDP page list independently.
 
-`obsidian-launch.sh` doesn't touch any vault at all (it only starts/stops the
-Obsidian process and polls the CDP HTTP endpoint), so no vault guard applies to it.
+`obsidian-launch.sh` mostly doesn't touch any vault (it starts/stops the Obsidian
+process and polls the CDP HTTP endpoint). The one part that does is opening the
+test vault when it has no window, since that names a specific vault and makes
+Obsidian write its `.obsidian/workspace.json` — so that step runs guards 1–3
+above before it opens anything. Everything else in the script runs without a
+vault configured at all.
 
 ## Environment-specific configuration
 
@@ -142,10 +152,15 @@ offer to record it.
 
 All scripts live in `scripts/` and use only Node's built-ins (`fetch`,
 `WebSocket`, `fs`) plus macOS system tools (`osascript`, `screencapture`, `python3`
-+ PyObjC's `Quartz`) — no `npm install` required, so they work in a worktree before
-`mise run main:init` has ever been run.
++ PyObjC's `Quartz`) — no `npm install` required, so they work in a worktree
+before dependencies have ever been installed.
 
-### `obsidian-launch.sh [--restart]`
+`scripts/lib/` holds the pieces more than one script needs: `vault-window.mjs`
+(which CDP page belongs to which vault, the guard wrapper, the CDP evaluate
+call) and `cdp-pages.mjs`, a tiny CLI over the page list so the bash scripts
+don't each carry their own copy of the title rule.
+
+### `obsidian-launch.sh [--restart] [--no-open-vault]`
 
 Ensures Obsidian is running with `--remote-debugging-port=$OBSIDIAN_CDP_PORT`
 (default port `9333` — `9222` is often already taken by a running Chrome). If CDP
@@ -154,10 +169,41 @@ titles and exits). Otherwise it quits any running Obsidian instance (Electron ap
 can't have `--remote-debugging-port` turned on after the fact) and relaunches it
 with the flag, then polls until CDP responds.
 
-Not vault-specific — it affects every open vault's window (all vaults reopen, no
-data loss, but any unsaved modal/dialog state in another vault's window is lost).
-It only actually restarts when required; running it opportunistically before other
-scripts is safe and usually a no-op.
+Starting the app is not vault-specific — it affects every open vault's window
+(all vaults reopen, no data loss, but any unsaved modal/dialog state in another
+vault's window is lost). It only actually restarts when required; running it
+opportunistically before other scripts is safe and usually a no-op.
+
+**It also makes sure the test vault has a window.** Obsidian only reopens the
+vaults that were open when it was last quit, and the test vault frequently isn't
+one of them — which used to leave every other script failing with "found no page
+target" and nothing explaining why. When `OBSIDIAN_TEST_VAULT_NAME` is set, this
+script waits ~8s for that vault's window to appear on its own and, if it doesn't,
+opens the vault via `obsidian://open?vault=<name>` and waits for it. Opening a
+vault by name is vault-specific, so that step runs the same filesystem-side
+guards as the other scripts (name/path agreement plus the marker file) before it
+names anything — opening a vault makes Obsidian write its own
+`.obsidian/workspace.json`, which is the kind of write the marker authorizes.
+Pass `--no-open-vault` to suppress this.
+
+### `obsidian-wait.sh [--timeout SEC] [--min-reminders N]`
+
+```
+.claude/skills/obsidian-e2e/scripts/obsidian-wait.sh --min-reminders 3
+# => { "ready": true, "reminders": 13, "overdue": 0 }
+```
+
+Blocks until the plugin in the test vault's window is actually ready: the window
+answers CDP, `app.plugins.plugins["obsidian-reminder-plugin"]` exists, and its
+initial full-vault scan has finished (`data.scanned.value === true`). Use this
+instead of `sleep 20` after a launch or restart — it typically returns in well
+under a second, and it can't return too early the way a fixed sleep can.
+
+`--min-reminders N` additionally waits for, and then asserts, a parsed reminder
+count. Always pass it: a settings mismatch makes fixtures parse to *zero*
+reminders with no error anywhere (see "Fixtures depend on settings" below), and
+without this assertion that failure shows up much later as a confusing "the
+reminder never fired."
 
 ### `obsidian-eval.mjs`
 
@@ -176,6 +222,16 @@ node .claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs --file /path/to/scrip
 Evaluates JavaScript inside the matched Obsidian window as the body of an async
 function (`return`/`await` both work). Prints the result as JSON to stdout;
 exceptions go to stderr with a non-zero exit.
+
+**When the vault has several windows** (a popped-out note, or the separate
+window Obsidian 1.13+ uses for settings), the candidates are classified with a
+fixed read-only DOM probe and `--window` picks one: `main` (default) is the
+window with the ribbon and the root split, `any` accepts whichever single window
+can be driven. There is deliberately no `--window settings`: **the settings
+window's JS context has no `app` global**, so it can't prove which vault it
+belongs to, the safety guard can never pass there, and nothing may be evaluated
+in it. To see the settings screen, screenshot it (`obsidian-shot.sh
+--title-contains`).
 
 Because production builds don't mangle property names (esbuild only does that with
 an explicit `mangleProps`, which this project's `esbuild.config.mjs` doesn't set),
@@ -220,11 +276,15 @@ resolves inside the vault root — this is what blocks `../`-style escapes or a
 symlink pointing outside the vault. Obsidian must already be running and watching
 the vault for the external file change to be picked up.
 
-### `obsidian-shot.sh <output-path.png>`
+### `obsidian-shot.sh [--title-contains TEXT] <output-path.png>`
 
 ```
 # (OBSIDIAN_TEST_VAULT_NAME already exported — see above)
 .claude/skills/obsidian-e2e/scripts/obsidian-shot.sh /path/to/scratchpad/shot.png
+
+# when the vault has several windows open, narrow by an extra title substring
+# (the settings window's title starts with the localized name of that screen):
+.claude/skills/obsidian-e2e/scripts/obsidian-shot.sh --title-contains '設定' /path/to/settings.png
 ```
 
 Screenshots the on-screen Obsidian window belonging to the named vault.
@@ -238,10 +298,20 @@ prone to timing out in testing; drive the UI through CDP/DOM instead (see
 
 Window discovery goes through Quartz's `CGWindowListCopyWindowInfo` (via
 `python3` + PyObjC), matching `kCGWindowOwnerName == "Obsidian"` and a
-`kCGWindowName` containing `" - <VAULT_NAME> - "`, then
-`screencapture -x -o -l <windowID>`. Write the output somewhere outside any vault
-(the session scratchpad is the right place) — this script does not stop you from
-pointing the output path inside a vault, so don't.
+`kCGWindowName` that belongs to the vault (same two title shapes as the CDP
+side — see "Known limitations"), then `screencapture -x -o -l <windowID>`. Write
+the output somewhere outside any vault (the session scratchpad is the right
+place) — this script does not stop you from pointing the output path inside a
+vault, so don't.
+
+Exactly one window must survive the filter. If the vault has more than one open,
+narrow it with `--title-contains`; the error message lists the titles it saw.
+The cross-check against the CDP page list still runs, and now requires the two
+sources to agree on *how many* windows the vault has, rather than requiring that
+number to be one.
+
+This is the only way to inspect the settings screen, since CDP can't evaluate
+anything in that window (no `app` global — see `obsidian-eval.mjs` above).
 
 ## What cannot be automated
 
@@ -257,24 +327,94 @@ Be upfront about these with the user rather than trying to fake a check:
 - **Subjective UI/UX judgment** — animation smoothness, whether a layout "looks
   right." This skill can assert DOM state and pixel-diff screenshots at best; it
   can't judge aesthetics.
+- **Clicking anything in the settings window.** Its JS context has no `app`, so
+  the vault guard can't pass and nothing may be evaluated there. You can
+  screenshot it, and you can read and write every setting's value from the main
+  window via `plugin.settings.<key>.rawValue.value` — what you can't do is drive
+  the actual toggles and text fields.
 
 For these, hand off to `manual-verify`.
+
+## Fixtures depend on settings
+
+The plugin's `data.json` does not live in the vault. It lives in the plugin
+directory, which is a symlink to a repository checkout — so **swapping the
+symlink swaps the settings too**, and a fresh worktree that has never been used
+starts with no `data.json` at all, i.e. every setting at its default.
+
+That matters because reminder syntax is only recognized when the matching format
+is enabled. The `⏰ YYYY-MM-DD HH:mm` fixtures under `reminder-test/` need both
+`enableTasksPluginReminderFormat` and `useCustomEmojiForTasksPlugin` on, and
+neither is on by default. With defaults, every fixture parses to **zero
+reminders, with no error anywhere** — nothing fires, and it looks like the
+feature under test is broken.
+
+So set the baseline explicitly at the start of a run and assert it took effect:
+
+```
+# one-time per checkout, from the main window
+node .../obsidian-eval.mjs '
+  const p = app.plugins.plugins["obsidian-reminder-plugin"];
+  p.settings.settings.forEach(s => {
+    if (s.key === "enableTasksPluginReminderFormat") s.rawValue.value = true;
+  });
+  p.settings.useCustomEmojiForTasksPlugin.rawValue.value = true;
+  await p.fileSystem.reloadRemindersInAllFiles();
+  await p.data.save(true);
+  return p._reminders.reminders.length;'
+
+.../obsidian-wait.sh --min-reminders 3   # fails loudly if the fixtures did not parse
+```
+
+Note `p.settings.settings.forEach` for the format toggles: the per-format
+settings aren't exposed as named fields on `Settings`, only through the
+collection.
+
+## Testing startup / restart behavior
+
+Anything about what happens *when Obsidian starts* (mute state surviving a
+restart, do-not-disturb resuming, the initial scan) needs state on disk before
+the restart, and the plugin only writes `data.json` when it considers itself
+changed. Force it rather than hoping a periodic save lands:
+
+```
+# 1. get into the state you want to persist (fire, mute, run a command, ...)
+# 2. force a save and confirm it hit the disk
+node .../obsidian-eval.mjs 'await app.plugins.plugins["obsidian-reminder-plugin"].data.save(true); return "saved";'
+grep -o '"muted":[a-z]*' <checkout>/data.json
+
+# 3. restart, wait properly, then assert
+.../obsidian-launch.sh --restart
+.../obsidian-wait.sh --min-reminders 3
+node .../obsidian-eval.mjs '
+  const p = app.plugins.plugins["obsidian-reminder-plugin"];
+  return { toasts: [...p.ui.reminderNotifier.toastManager.toasts.keys()] };'
+```
+
+Reading `data.json` back between steps 2 and 3 is worth the extra line: it
+separates "the plugin never persisted it" from "the plugin persisted it and
+discarded it on load," which are the two failure modes that look identical from
+the UI.
 
 ## Typical workflow
 
 1. **Build** the checkout under test:
-   `mise exec -- npm run build` (run `mise run main:init` first in a worktree
-   that has no `node_modules` yet).
+   `mise exec -- npm run build` (in a worktree with no `node_modules` yet, run
+   `mise exec -- npm install` first — **not** `mise run main:init`, whose shell
+   picks up a different npm and rewrites `package-lock.json`).
 2. **Point the vault's plugin symlink** at that checkout (same gotcha as
    `manual-verify`: this is disruptive to whoever else might be using the
    symlink, and Obsidian must not be actively writing `data.json` while you swap
    it — quit Obsidian first if you're also touching settings).
-3. **Ensure Obsidian is up with CDP**: `obsidian-launch.sh`.
-4. **Fire** the reminder(s) you need: `reminder-fire.sh`.
-5. **Operate/verify** via `obsidian-eval.mjs` (click buttons, read state) and/or
+3. **Ensure Obsidian is up with CDP and the test vault is open**:
+   `obsidian-launch.sh`.
+4. **Wait for readiness and check the fixtures parsed**:
+   `obsidian-wait.sh --min-reminders <N>`.
+5. **Fire** the reminder(s) you need: `reminder-fire.sh`.
+6. **Operate/verify** via `obsidian-eval.mjs` (click buttons, read state) and/or
    `obsidian-shot.sh` (visual capture for the user to glance at, or for
    comparison).
-6. **Clean up** (see below).
+7. **Clean up** (see below).
 
 ## A concrete, actually-run verification example
 
@@ -332,13 +472,22 @@ The toast DOM shape used above: `.reminder-toast-card` is one toast; inside it,
 
 ## Known limitations
 
-- **The `" - <VAULT_NAME> - "` title substring match isn't airtight.** If the
-  *active note's own title* happens to contain a hyphen-padded segment that matches
-  another vault's name (e.g. a note titled `"Report - otherVault - Draft"` open
-  inside the test vault), a script targeting `otherVault` could match the wrong
-  window. This is why the marker-file check is the real guard and the title match
-  is only used for disambiguating *which already-approved vault's window* to talk
-  to — never treat title matching alone as sufficient permission.
+- **A vault's window is recognized by two title shapes**, because Obsidian uses
+  both: `"<note> - <vault> - Obsidian <version>"` once a note is open, and
+  `"<vault> - Obsidian <version>"` while none is. Matching only the first (which
+  this skill originally did) loses the window during the first seconds after a
+  launch — exactly when a script is polling for it. The rule lives in one place,
+  `scripts/lib/vault-window.mjs`, with a deliberate second copy in Python inside
+  `obsidian-shot.sh`, which can't import it.
+- **Neither title shape is airtight.** If the *active note's own title* happens
+  to contain a hyphen-padded segment that matches another vault's name (e.g. a
+  note titled `"Report - otherVault - Draft"` open inside the test vault), a
+  script targeting `otherVault` could match the wrong window. This is why the
+  marker-file check is the real guard and the title match is only used for
+  disambiguating *which already-approved vault's window* to talk to — never treat
+  title matching alone as sufficient permission.
+- **The settings window can't be driven, only photographed** — no `app` global,
+  so the guard can't pass. See `obsidian-eval.mjs` and `obsidian-shot.sh` above.
 - **Internal state access (`ui.reminderNotifier`, etc.) is refactor-fragile** by
   nature — see the note under `obsidian-eval.mjs` above.
 - **Marker-file existence is checked at two different times** (filesystem-side

--- a/.claude/skills/obsidian-e2e/scripts/lib/cdp-pages.mjs
+++ b/.claude/skills/obsidian-e2e/scripts/lib/cdp-pages.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Small CLI over the CDP page list, so the bash scripts don't each carry their
+// own inline copy of the title-matching rule (see lib/vault-window.mjs).
+//
+// Usage:
+//   node lib/cdp-pages.mjs --vault <name> [--port 9333] [--count | --all]
+//
+//   (default)  print the titles of the pages belonging to <vault>, one per line
+//   --count    print just how many pages belong to <vault>
+//   --all      print every page title, whichever vault it belongs to
+//
+// Exits 4 if the CDP endpoint isn't reachable at all (prints nothing).
+
+import { allPageTitles, fetchTargets, vaultPages } from "./vault-window.mjs";
+
+const argv = process.argv.slice(2);
+function optionValue(name) {
+  const i = argv.indexOf(name);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+const vault = optionValue("--vault");
+const port = optionValue("--port") || process.env.OBSIDIAN_CDP_PORT || "9333";
+const wantsCount = argv.includes("--count");
+const wantsAll = argv.includes("--all");
+
+if (!vault && !wantsAll) {
+  console.error("usage: node lib/cdp-pages.mjs --vault <name> [--port N] [--count | --all]");
+  process.exit(2);
+}
+
+let targets;
+try {
+  targets = await fetchTargets(port);
+} catch {
+  process.exit(4);
+}
+
+if (wantsAll) {
+  for (const title of allPageTitles(targets)) {
+    console.log(title);
+  }
+} else if (wantsCount) {
+  console.log(vaultPages(targets, vault).length);
+} else {
+  for (const page of vaultPages(targets, vault)) {
+    console.log(page.title);
+  }
+}

--- a/.claude/skills/obsidian-e2e/scripts/lib/vault-window.mjs
+++ b/.claude/skills/obsidian-e2e/scripts/lib/vault-window.mjs
@@ -1,0 +1,147 @@
+// Shared rules for finding the CDP page target that belongs to a given vault.
+//
+// Obsidian window titles come in two shapes, and only matching the first one
+// (which is what this skill originally did) silently loses the window during
+// the first seconds after a launch:
+//
+//   "<note title> - <vault> - Obsidian <version>"   once a note is open
+//   "<vault> - Obsidian <version>"                  while no note is open yet
+//
+// The second form is what you see right after Obsidian starts, before the
+// workspace has restored a note — exactly when a script polling for the window
+// runs. The prefix form is anchored at the start of the title and immediately
+// followed by " - Obsidian", so it is stricter, not looser, than the infix
+// form: a note titled "notes" inside some other vault produces
+// "notes - othervault - Obsidian ...", which does not match the prefix rule for
+// vault "notes".
+//
+// Neither form is a permission check. See SKILL.md: the marker file is the only
+// thing that expresses consent; these rules only decide *which already-approved
+// vault's window* to talk to.
+
+export const MARKER_RELATIVE_PATH = ".obsidian/obsidian-e2e-allowed";
+
+export function titleMatchesVault(title, vault) {
+  if (typeof title !== "string") {
+    return false;
+  }
+  return title.includes(` - ${vault} - `) || title.startsWith(`${vault} - Obsidian`);
+}
+
+export function vaultPages(targets, vault) {
+  return targets.filter((t) => t.type === "page" && titleMatchesVault(t.title, vault));
+}
+
+export function allPageTitles(targets) {
+  return targets.filter((t) => t.type === "page").map((t) => t.title ?? "");
+}
+
+export async function fetchTargets(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/json/list`);
+  return await res.json();
+}
+
+export function evaluateInPage(webSocketDebuggerUrl, expression, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(webSocketDebuggerUrl);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("timed out waiting for CDP response"));
+    }, timeoutMs);
+
+    ws.addEventListener("open", () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          method: "Runtime.evaluate",
+          params: {
+            expression,
+            awaitPromise: true,
+            returnByValue: true,
+          },
+        }),
+      );
+    });
+
+    ws.addEventListener("message", (event) => {
+      let msg;
+      try {
+        msg = JSON.parse(event.data.toString());
+      } catch {
+        return;
+      }
+      if (msg.id !== 1) return;
+      clearTimeout(timeout);
+      ws.close();
+
+      if (msg.error) {
+        reject(new Error(`CDP error: ${JSON.stringify(msg.error)}`));
+        return;
+      }
+      const result = msg.result;
+      if (result.exceptionDetails) {
+        reject(
+          new Error(
+            result.exceptionDetails.exception?.description ||
+              JSON.stringify(result.exceptionDetails),
+          ),
+        );
+        return;
+      }
+      resolve(result.result?.value);
+    });
+
+    ws.addEventListener("error", (event) => {
+      clearTimeout(timeout);
+      reject(new Error(`WebSocket error: ${event.message || "unknown"}`));
+    });
+  });
+}
+
+/**
+ * Wraps `code` so that, before any of it runs, the page re-reads its own vault
+ * name and re-checks the marker file. See safety guard 4 in obsidian-eval.mjs.
+ */
+export function guardExpression(code, vault) {
+  return `(async () => {
+    const __vault = app.vault.getName();
+    if (__vault !== ${JSON.stringify(vault)}) {
+      throw new Error(
+        "obsidian-e2e safety guard: expected vault " + ${JSON.stringify(vault)} +
+        " but this page reports vault " + __vault
+      );
+    }
+    const __allowed = await app.vault.adapter.exists(${JSON.stringify(MARKER_RELATIVE_PATH)});
+    if (!__allowed) {
+      throw new Error(
+        "obsidian-e2e safety guard: marker file " + ${JSON.stringify(MARKER_RELATIVE_PATH)} +
+        " not found in this vault. Refusing to run user code."
+      );
+    }
+    return await (async () => {
+${code}
+    })();
+  })()`;
+}
+
+/**
+ * A fixed, read-only probe used to tell one of a vault's windows from another
+ * once more than one is open. It runs through the same vault/marker guard as
+ * user code, and only reads the DOM — it never writes anything.
+ *
+ * A page where the guard itself cannot run is not classified here at all: it
+ * throws, and the caller records it as unusable. The settings window Obsidian
+ * 1.13+ opens is exactly that case — its JS context has no `app` global, so
+ * `app.vault.getName()` raises ReferenceError and there is no way to confirm
+ * which vault that window belongs to. Nothing may be evaluated there. To see
+ * the settings screen, screenshot it: obsidian-shot.sh --title-contains.
+ */
+export const WINDOW_KIND_PROBE = `
+  const hasRootSplit = !!document.querySelector(".workspace-split.mod-root");
+  const hasRibbon = !!document.querySelector(".workspace-ribbon");
+  return {
+    kind: (hasRibbon && hasRootSplit) ? "main" : "other",
+    hasRootSplit, hasRibbon,
+    title: document.title,
+  };
+`;

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-eval.mjs
@@ -17,10 +17,19 @@
 //      is an explicit, physical, per-vault opt-in that has to be placed by a
 //      human who understands "scripts under this skill will rewrite whatever is
 //      in this vault."
-//   3. Among the CDP page targets, exactly one page's title must contain
-//      " - <VAULT_NAME> - " (the substring Obsidian puts between the active
-//      note's title and "Obsidian <version>" in its window/tab title). Zero
-//      matches or more than one match both abort the run.
+//   3. Among the CDP page targets, the pages belonging to <VAULT_NAME> are
+//      selected by title (see lib/vault-window.mjs), and exactly one of them
+//      must survive the --window filter. Zero matches or more than one match
+//      both abort the run.
+//
+//      One vault can legitimately own several windows: Obsidian 1.13+ opens
+//      Settings in its own window, and notes can be popped out. Rather than
+//      refusing outright whenever there is more than one (which is what this
+//      script used to do, and which made anything involving the settings tab
+//      untestable), the candidates are classified with a fixed, read-only DOM
+//      probe and --window picks the one you meant. The probe runs through the
+//      same guard as user code, so a page that isn't the expected vault still
+//      never executes anything.
 //   4. The code that actually runs in the page is wrapped so its first actions
 //      are to re-read app.vault.getName() from inside the page and compare it
 //      again to VAULT_NAME, AND re-check the marker file via
@@ -37,6 +46,7 @@
 // Usage:
 //   node obsidian-eval.mjs '<javascript>'
 //   node obsidian-eval.mjs --file path/to/script.js
+//   node obsidian-eval.mjs --window any '<javascript>'
 //
 // The JavaScript is treated as the body of an async function: `return <value>;`
 // sends a value back, and `await` works. The result is printed to stdout as JSON
@@ -45,8 +55,21 @@
 
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { basename, join } from "node:path";
+import {
+  MARKER_RELATIVE_PATH,
+  WINDOW_KIND_PROBE,
+  allPageTitles,
+  evaluateInPage,
+  fetchTargets,
+  guardExpression,
+  vaultPages,
+} from "./lib/vault-window.mjs";
 
-const MARKER_RELATIVE_PATH = ".obsidian/obsidian-e2e-allowed";
+// "settings" is deliberately absent: Obsidian 1.13+ opens settings in a window
+// whose JS context has no `app`, so the vault guard can never pass there and
+// nothing may be evaluated in it. Screenshot it instead (obsidian-shot.sh
+// --title-contains).
+const WINDOW_KINDS = ["main", "any"];
 
 function usageError(message) {
   console.error(`error: ${message}`);
@@ -54,6 +77,7 @@ function usageError(message) {
   console.error("usage:");
   console.error("  node obsidian-eval.mjs '<javascript>'");
   console.error("  node obsidian-eval.mjs --file path/to/script.js");
+  console.error("  node obsidian-eval.mjs --window <main|any> '<javascript>'");
   console.error("");
   console.error("required env: OBSIDIAN_TEST_VAULT_NAME, OBSIDIAN_TEST_VAULT_PATH");
   console.error("optional env: OBSIDIAN_CDP_PORT (default 9333)");
@@ -61,20 +85,60 @@ function usageError(message) {
 }
 
 function parseArgs(argv) {
-  if (argv.length === 0) {
+  let windowKind = "main";
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--window") {
+      windowKind = argv[++i];
+      if (!WINDOW_KINDS.includes(windowKind)) {
+        usageError(`--window must be one of ${WINDOW_KINDS.join(", ")}`);
+      }
+      continue;
+    }
+    rest.push(argv[i]);
+  }
+  if (rest.length === 0) {
     usageError("missing JavaScript to evaluate");
   }
-  if (argv[0] === "--file") {
-    const path = argv[1];
-    if (!path) {
-      usageError("--file requires a path argument");
-    }
-    return readFileSync(path, "utf8");
-  }
-  if (argv[0] === "-h" || argv[0] === "--help") {
+  if (rest[0] === "-h" || rest[0] === "--help") {
     usageError("help requested");
   }
-  return argv[0];
+  if (rest[0] === "--file") {
+    if (!rest[1]) {
+      usageError("--file requires a path argument");
+    }
+    return { code: readFileSync(rest[1], "utf8"), windowKind };
+  }
+  return { code: rest[0], windowKind };
+}
+
+/**
+ * Narrows several windows of the same vault down to the one the caller means.
+ * Only reached when the title match alone is ambiguous, so the common
+ * single-window case costs no extra CDP round trips.
+ *
+ * A page that fails the probe is recorded as unusable rather than treated as a
+ * candidate: the probe runs behind the vault/marker guard, so failing it means
+ * the page could not prove which vault it belongs to, and running anything
+ * there is exactly what the guard exists to prevent.
+ */
+async function classifyPages(pages, vault) {
+  const probe = guardExpression(WINDOW_KIND_PROBE, vault);
+  const classified = [];
+  for (const page of pages) {
+    try {
+      const info = await evaluateInPage(page.webSocketDebuggerUrl, probe, 10_000);
+      classified.push({ page, kind: info.kind, title: page.title });
+    } catch (e) {
+      classified.push({
+        page,
+        kind: "unusable",
+        title: page.title,
+        reason: e.message.split("\n")[0],
+      });
+    }
+  }
+  return classified;
 }
 
 async function main() {
@@ -88,7 +152,7 @@ async function main() {
     );
   }
   const port = process.env.OBSIDIAN_CDP_PORT || "9333";
-  const code = parseArgs(process.argv.slice(2));
+  const { code, windowKind } = parseArgs(process.argv.slice(2));
 
   // --- Safety guard 1: path and name must agree ------------------------------
   let realVaultPath;
@@ -122,8 +186,7 @@ async function main() {
   // --- Safety guard 3: exactly one matching CDP page target ------------------
   let targets;
   try {
-    const res = await fetch(`http://127.0.0.1:${port}/json/list`);
-    targets = await res.json();
+    targets = await fetchTargets(port);
   } catch (e) {
     console.error(
       `error: could not reach CDP endpoint at http://127.0.0.1:${port}/json/list (${e.message}). ` +
@@ -132,53 +195,49 @@ async function main() {
     process.exit(4);
   }
 
-  const needle = ` - ${vault} - `;
-  const pages = targets.filter(
-    (t) => t.type === "page" && typeof t.title === "string" && t.title.includes(needle),
-  );
+  const pages = vaultPages(targets, vault);
 
-  if (pages.length !== 1) {
-    console.error(
-      `refusing to run: expected exactly 1 page target whose title contains ${JSON.stringify(
-        needle,
-      )}, found ${pages.length}.`,
-    );
-    const allPages = targets.filter((t) => t.type === "page");
-    if (allPages.length === 0) {
+  function abortWithPageList(reason) {
+    console.error(`refusing to run: ${reason}`);
+    const titles = allPageTitles(targets);
+    if (titles.length === 0) {
       console.error("  (no page targets at all)");
     } else {
       console.error("  page titles seen:");
-      for (const t of allPages) {
-        console.error(`    - ${t.title}`);
+      for (const title of titles) {
+        console.error(`    - ${title}`);
       }
     }
     process.exit(3);
   }
 
-  const target = pages[0];
+  if (pages.length === 0) {
+    abortWithPageList(
+      `found no page target belonging to vault ${JSON.stringify(vault)}. ` +
+        "Is that vault open? obsidian-launch.sh opens it for you.",
+    );
+  }
+
+  let target = pages[0];
+  if (pages.length > 1) {
+    const classified = await classifyPages(pages, vault);
+    const usable = classified.filter((c) => c.kind !== "unusable");
+    const wanted = windowKind === "main" ? usable.filter((c) => c.kind === "main") : usable;
+    if (wanted.length !== 1) {
+      console.error(
+        `refusing to run: vault ${JSON.stringify(vault)} has ${pages.length} windows open, ` +
+          `and ${wanted.length} of them match --window ${windowKind} (expected exactly 1).`,
+      );
+      for (const c of classified) {
+        console.error(`    - ${c.title} => ${c.kind}${c.reason ? ` (${c.reason})` : ""}`);
+      }
+      process.exit(3);
+    }
+    target = wanted[0].page;
+  }
 
   // --- Safety guard 4: re-check vault name AND marker file from inside the page
-  const guardedExpression = `(async () => {
-    const __vault = app.vault.getName();
-    if (__vault !== ${JSON.stringify(vault)}) {
-      throw new Error(
-        "obsidian-eval safety guard: expected vault " + ${JSON.stringify(vault)} +
-        " but this page reports vault " + __vault
-      );
-    }
-    const __allowed = await app.vault.adapter.exists(${JSON.stringify(MARKER_RELATIVE_PATH)});
-    if (!__allowed) {
-      throw new Error(
-        "obsidian-eval safety guard: marker file " + ${JSON.stringify(MARKER_RELATIVE_PATH)} +
-        " not found in this vault. Refusing to run user code."
-      );
-    }
-    return await (async () => {
-${code}
-    })();
-  })()`;
-
-  const value = await evaluateInPage(target.webSocketDebuggerUrl, guardedExpression);
+  const value = await evaluateInPage(target.webSocketDebuggerUrl, guardExpression(code, vault));
 
   if (value === undefined) {
     console.log("(undefined)");
@@ -187,63 +246,6 @@ ${code}
   } else {
     console.log(JSON.stringify(value, null, 2));
   }
-}
-
-function evaluateInPage(webSocketDebuggerUrl, expression) {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(webSocketDebuggerUrl);
-    const timeout = setTimeout(() => {
-      ws.close();
-      reject(new Error("timed out waiting for CDP response"));
-    }, 30_000);
-
-    ws.addEventListener("open", () => {
-      ws.send(
-        JSON.stringify({
-          id: 1,
-          method: "Runtime.evaluate",
-          params: {
-            expression,
-            awaitPromise: true,
-            returnByValue: true,
-          },
-        }),
-      );
-    });
-
-    ws.addEventListener("message", (event) => {
-      let msg;
-      try {
-        msg = JSON.parse(event.data.toString());
-      } catch {
-        return;
-      }
-      if (msg.id !== 1) return;
-      clearTimeout(timeout);
-      ws.close();
-
-      if (msg.error) {
-        reject(new Error(`CDP error: ${JSON.stringify(msg.error)}`));
-        return;
-      }
-      const result = msg.result;
-      if (result.exceptionDetails) {
-        reject(
-          new Error(
-            result.exceptionDetails.exception?.description ||
-              JSON.stringify(result.exceptionDetails),
-          ),
-        );
-        return;
-      }
-      resolve(result.result?.value);
-    });
-
-    ws.addEventListener("error", (event) => {
-      clearTimeout(timeout);
-      reject(new Error(`WebSocket error: ${event.message || "unknown"}`));
-    });
-  });
 }
 
 main().catch((e) => {

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-launch.sh
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-launch.sh
@@ -3,12 +3,21 @@
 # obsidian-eval.mjs / obsidian-shot.sh / reminder-fire.sh have something to
 # talk to.
 #
-# This script is NOT vault-specific — it operates on the Obsidian *application*,
-# which on this machine reopens whatever vaults were open last time as separate
-# windows. It never reads or writes inside any vault; it only starts/stops the
-# app process and polls the CDP HTTP endpoint. The per-vault safety guards
-# (marker file, vault name match) live in the other scripts, which is where
-# they matter.
+# Starting the app is NOT vault-specific — it operates on the Obsidian
+# *application*, which reopens whatever vaults were open last time as separate
+# windows. That part never reads or writes inside any vault; it only
+# starts/stops the app process and polls the CDP HTTP endpoint.
+#
+# Obsidian only reopens the vaults that happened to be open when it was last
+# quit, and the test vault is frequently not among them — which used to leave
+# every other script in this skill failing with "found no page target," with
+# nothing explaining why. So if OBSIDIAN_TEST_VAULT_NAME is set and no window
+# belongs to it, this script opens that one vault via the obsidian:// URI and
+# waits for its window. That step *is* vault-specific, so it carries the same
+# filesystem-side guards as the other scripts (name/path agreement plus the
+# obsidian-e2e-allowed marker) before naming a vault to open. Opening a vault
+# makes Obsidian write its own .obsidian/workspace.json, which is exactly the
+# kind of write the marker exists to authorize.
 #
 # Restarting Obsidian does not lose vault data (Obsidian saves on every edit),
 # but it does close whatever windows/dialogs/unsaved-modal-state existed, and
@@ -17,40 +26,102 @@
 # passes --restart).
 #
 # Usage:
-#   obsidian-launch.sh          # ensure CDP is up; start/restart only if needed
-#   obsidian-launch.sh --restart  # force a quit+relaunch even if CDP already works
+#   obsidian-launch.sh              # ensure CDP is up; start/restart only if needed
+#   obsidian-launch.sh --restart    # force a quit+relaunch even if CDP already works
+#   obsidian-launch.sh --no-open-vault   # never open the test vault, even if missing
 #
 # Env:
-#   OBSIDIAN_CDP_PORT   default 9333 (9222 is often already taken by Chrome)
+#   OBSIDIAN_CDP_PORT          default 9333 (9222 is often already taken by Chrome)
+#   OBSIDIAN_TEST_VAULT_NAME   optional here; when set (with _PATH), its window is ensured
+#   OBSIDIAN_TEST_VAULT_PATH   required whenever _NAME is set
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CDP_PAGES="$SCRIPT_DIR/lib/cdp-pages.mjs"
+
 PORT="${OBSIDIAN_CDP_PORT:-9333}"
 FORCE_RESTART=0
-if [[ "${1:-}" == "--restart" ]]; then
-  FORCE_RESTART=1
-fi
+OPEN_VAULT=1
+for arg in "$@"; do
+  case "$arg" in
+    --restart) FORCE_RESTART=1 ;;
+    --no-open-vault) OPEN_VAULT=0 ;;
+    *)
+      echo "error: unknown argument $arg" >&2
+      echo "usage: obsidian-launch.sh [--restart] [--no-open-vault]" >&2
+      exit 2
+      ;;
+  esac
+done
 
 cdp_version_json() {
   curl -s --max-time 2 "http://127.0.0.1:${PORT}/json/version" 2>/dev/null || true
 }
 
 list_page_titles() {
-  curl -s --max-time 2 "http://127.0.0.1:${PORT}/json/list" 2>/dev/null \
-    | node -e '
-        let data = "";
-        process.stdin.on("data", (c) => (data += c));
-        process.stdin.on("end", () => {
-          try {
-            const targets = JSON.parse(data);
-            for (const t of targets) {
-              if (t.type === "page") console.log("  - " + t.title);
-            }
-          } catch {
-            // ignore
-          }
-        });
-      '
+  node "$CDP_PAGES" --all --port "$PORT" 2>/dev/null | sed 's/^/  - /' || true
+}
+
+vault_page_count() {
+  node "$CDP_PAGES" --vault "$1" --port "$PORT" --count 2>/dev/null || echo 0
+}
+
+# Ensures a window for OBSIDIAN_TEST_VAULT_NAME exists, opening that vault if
+# it doesn't. Silently does nothing when the env vars aren't set — this script
+# is also useful without a vault configured.
+ensure_test_vault_open() {
+  local vault="${OBSIDIAN_TEST_VAULT_NAME:-}"
+  if [[ "$OPEN_VAULT" -eq 0 || -z "$vault" ]]; then
+    return 0
+  fi
+
+  # Right after a launch, Obsidian's windows appear over a few seconds. Give
+  # the vault a moment to show up on its own before deciding to open it.
+  for _ in $(seq 1 16); do
+    if [[ "$(vault_page_count "$vault")" != "0" ]]; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  local vault_path="${OBSIDIAN_TEST_VAULT_PATH:-}"
+  if [[ -z "$vault_path" ]]; then
+    echo "warning: vault '$vault' has no window open, but OBSIDIAN_TEST_VAULT_PATH is unset, so it cannot be opened safely." >&2
+    return 0
+  fi
+
+  # Same filesystem-side guards the other scripts use: naming a vault is not
+  # consent, the marker file is.
+  local real_path
+  real_path="$(cd "$vault_path" 2>/dev/null && pwd -P || true)"
+  if [[ -z "$real_path" ]]; then
+    echo "error: OBSIDIAN_TEST_VAULT_PATH does not resolve: $vault_path" >&2
+    exit 3
+  fi
+  if [[ "$(basename "$real_path")" != "$vault" ]]; then
+    echo "error: basename(OBSIDIAN_TEST_VAULT_PATH) is '$(basename "$real_path")', which does not match OBSIDIAN_TEST_VAULT_NAME '$vault'." >&2
+    exit 3
+  fi
+  if [[ ! -f "$real_path/.obsidian/obsidian-e2e-allowed" ]]; then
+    echo "refusing to open vault '$vault': no marker file at $real_path/.obsidian/obsidian-e2e-allowed (see SKILL.md)." >&2
+    exit 3
+  fi
+
+  echo "Vault '$vault' has no window open; opening it..."
+  local encoded
+  encoded="$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$vault")"
+  open "obsidian://open?vault=${encoded}"
+
+  for _ in $(seq 1 60); do
+    if [[ "$(vault_page_count "$vault")" != "0" ]]; then
+      echo "Vault '$vault' is open."
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "error: vault '$vault' did not open within 30s." >&2
+  exit 7
 }
 
 cdp_is_obsidian() {
@@ -66,6 +137,7 @@ if [[ "$FORCE_RESTART" -eq 0 ]]; then
   if [[ -n "$version_info" ]]; then
     if cdp_is_obsidian "$version_info"; then
       echo "Obsidian already reachable via CDP on port $PORT."
+      ensure_test_vault_open
       echo "Open page targets:"
       list_page_titles
       exit 0
@@ -104,6 +176,7 @@ for _ in $(seq 1 60); do
   version_info="$(cdp_version_json)"
   if [[ -n "$version_info" ]] && cdp_is_obsidian "$version_info"; then
     echo "Obsidian is up, CDP reachable on port $PORT."
+    ensure_test_vault_open
     echo "Open page targets:"
     list_page_titles
     exit 0

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-shot.sh
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-shot.sh
@@ -25,8 +25,22 @@
 # scripts, cross-checked against the CDP page list as a second, independent
 # source of truth.
 #
+# One vault can own several windows: Obsidian 1.13+ opens Settings in its own
+# window, and notes can be popped out. "Exactly one window for this vault" then
+# refuses to capture anything at all, which is what made the settings screen
+# impossible to screenshot. --title-contains narrows the candidates by an extra
+# substring of the window title, so `--title-contains 設定` (or whatever the
+# Settings screen is called in your Obsidian's language) picks that window.
+#
+# The narrowing is deliberately explicit rather than a main/settings guess:
+# a popped-out note and the settings window have title shapes that can't be
+# told apart reliably, and this script never evaluates anything inside a page,
+# so it has nothing but the title to go on. obsidian-eval.mjs, which can look
+# at the DOM, does classify windows — use --window there.
+#
 # Usage:
 #   obsidian-shot.sh <output-path.png>
+#   obsidian-shot.sh --title-contains '設定' <output-path.png>
 #
 # Env:
 #   OBSIDIAN_TEST_VAULT_NAME   required, no default
@@ -35,13 +49,22 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CDP_PAGES="$SCRIPT_DIR/lib/cdp-pages.mjs"
 
-if [[ $# -lt 1 ]]; then
-  echo "usage: obsidian-shot.sh <output-path.png>" >&2
+TITLE_CONTAINS=""
+OUTPUT_PATH=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title-contains) TITLE_CONTAINS="$2"; shift 2 ;;
+    *) OUTPUT_PATH="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$OUTPUT_PATH" ]]; then
+  echo "usage: obsidian-shot.sh [--title-contains TEXT] <output-path.png>" >&2
   echo "required env: OBSIDIAN_TEST_VAULT_NAME" >&2
   exit 2
 fi
-OUTPUT_PATH="$1"
 
 : "${OBSIDIAN_TEST_VAULT_NAME:?error: OBSIDIAN_TEST_VAULT_NAME is required (no default)}"
 PORT="${OBSIDIAN_CDP_PORT:-9333}"
@@ -51,20 +74,26 @@ PORT="${OBSIDIAN_CDP_PORT:-9333}"
 # match," which we want to report with our own message/exit code below, not
 # let `set -e` kill the script mid-substitution before we get the chance)
 set +e
-WINDOW_ID="$(python3 - "$OBSIDIAN_TEST_VAULT_NAME" << 'PYEOF'
+WINDOW_ID="$(python3 - "$OBSIDIAN_TEST_VAULT_NAME" "$TITLE_CONTAINS" << 'PYEOF'
 import sys
 import Quartz
 
 vault = sys.argv[1]
-needle = f" - {vault} - "
+extra = sys.argv[2]
+
+# Same two title shapes lib/vault-window.mjs matches: "<note> - <vault> - ..."
+# once a note is open, and "<vault> - Obsidian ..." while none is.
+def belongs_to_vault(name):
+    return f" - {vault} - " in name or name.startswith(f"{vault} - Obsidian")
 
 wins = Quartz.CGWindowListCopyWindowInfo(
     Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID
 )
-matches = [
+candidates = [
     w for w in wins
-    if w.get("kCGWindowOwnerName") == "Obsidian" and needle in (w.get("kCGWindowName") or "")
+    if w.get("kCGWindowOwnerName") == "Obsidian" and belongs_to_vault(w.get("kCGWindowName") or "")
 ]
+matches = [w for w in candidates if extra in (w.get("kCGWindowName") or "")]
 
 if len(matches) != 1:
     print(f"COUNT:{len(matches)}", file=sys.stderr)
@@ -73,37 +102,27 @@ if len(matches) != 1:
             print(f"  - {w.get('kCGWindowName', '')!r}", file=sys.stderr)
     sys.exit(1)
 
-print(matches[0]["kCGWindowNumber"])
+print(f"{matches[0]['kCGWindowNumber']} {len(candidates)}")
 PYEOF
 )"
 STATUS=$?
 set -e
 if [[ $STATUS -ne 0 || -z "$WINDOW_ID" ]]; then
-  echo "refusing to run: expected exactly 1 on-screen Obsidian window titled with ' - $OBSIDIAN_TEST_VAULT_NAME - ', see counts/titles above." >&2
+  echo "refusing to run: expected exactly 1 on-screen Obsidian window for vault '$OBSIDIAN_TEST_VAULT_NAME'${TITLE_CONTAINS:+ whose title also contains '$TITLE_CONTAINS'}, see counts/titles above." >&2
+  echo "(If this vault has several windows open — e.g. the settings window — narrow it with --title-contains.)" >&2
   exit 3
 fi
+WINDOW_CANDIDATES="${WINDOW_ID##* }"
+WINDOW_ID="${WINDOW_ID%% *}"
 
 # --- Guard B: cross-check against the CDP page list (independent source) ---
-PAGE_COUNT="$(curl -s --max-time 2 "http://127.0.0.1:${PORT}/json/list" 2>/dev/null \
-  | node -e '
-      let data = "";
-      process.stdin.on("data", (c) => (data += c));
-      process.stdin.on("end", () => {
-        const vault = process.argv[1];
-        const needle = ` - ${vault} - `;
-        try {
-          const targets = JSON.parse(data);
-          const n = targets.filter(
-            (t) => t.type === "page" && typeof t.title === "string" && t.title.includes(needle),
-          ).length;
-          console.log(n);
-        } catch {
-          console.log(0);
-        }
-      });
-    ' "$OBSIDIAN_TEST_VAULT_NAME")"
-if [[ "$PAGE_COUNT" != "1" ]]; then
-  echo "refusing to run: window list found exactly 1 match, but the CDP page list found $PAGE_COUNT (expected 1). Refusing due to disagreement between the two sources." >&2
+# The two sources must agree on how many windows this vault has. They are
+# allowed to be more than one (settings window, popped-out notes); what must
+# not happen is the on-screen window list and Obsidian's own page list telling
+# different stories about which windows exist.
+PAGE_COUNT="$(node "$CDP_PAGES" --vault "$OBSIDIAN_TEST_VAULT_NAME" --port "$PORT" --count 2>/dev/null || echo 0)"
+if [[ "$PAGE_COUNT" != "$WINDOW_CANDIDATES" ]]; then
+  echo "refusing to run: the on-screen window list found $WINDOW_CANDIDATES window(s) for vault '$OBSIDIAN_TEST_VAULT_NAME', but the CDP page list found $PAGE_COUNT. Refusing due to disagreement between the two sources." >&2
   echo "(Is Obsidian running with --remote-debugging-port=$PORT? See obsidian-launch.sh.)" >&2
   exit 3
 fi

--- a/.claude/skills/obsidian-e2e/scripts/obsidian-wait.sh
+++ b/.claude/skills/obsidian-e2e/scripts/obsidian-wait.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Wait until the reminder plugin in the test vault's window is actually ready
+# to be tested, instead of guessing with `sleep 20`.
+#
+# "Ready" means, in order: the vault's window answers CDP at all, the plugin
+# object exists, and its initial full-vault scan has completed
+# (`data.scanned.value === true`). Until the scan finishes, `reminders` is
+# empty and any assertion about reminders is meaningless — which is what makes
+# fixed sleeps flaky here.
+#
+# --min-reminders additionally waits for (and then asserts) a reminder count.
+# Use it as a cheap "did my fixtures actually parse?" check: reminder syntax
+# depends on which formats are enabled in settings, and a vault whose settings
+# don't enable the format your fixtures use reports zero reminders with no
+# error anywhere. See "Fixtures depend on settings" in SKILL.md.
+#
+# Usage:
+#   obsidian-wait.sh                        # wait for the plugin + initial scan
+#   obsidian-wait.sh --timeout 90           # default 60 seconds
+#   obsidian-wait.sh --min-reminders 3      # also require >= 3 parsed reminders
+#
+# Env: same as obsidian-eval.mjs (OBSIDIAN_TEST_VAULT_NAME/_PATH required).
+#
+# Exits 0 once ready (printing the final state as JSON), 1 on timeout.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TIMEOUT_SEC=60
+MIN_REMINDERS=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --timeout) TIMEOUT_SEC="$2"; shift 2 ;;
+    --min-reminders) MIN_REMINDERS="$2"; shift 2 ;;
+    *)
+      echo "usage: obsidian-wait.sh [--timeout SEC] [--min-reminders N]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+read -r -d '' PROBE <<EOF || true
+const plugin = app.plugins.plugins["obsidian-reminder-plugin"];
+if (!plugin) {
+  return { ready: false, reason: "plugin not loaded yet" };
+}
+if (!plugin.data || !plugin.data.scanned.value) {
+  return { ready: false, reason: "initial vault scan has not finished" };
+}
+const reminders = plugin._reminders.reminders.length;
+if (reminders < ${MIN_REMINDERS}) {
+  return { ready: false, reason: "only " + reminders + " reminders parsed", reminders };
+}
+return { ready: true, reminders, overdue: plugin._reminders.getExpiredReminders(plugin.settings.reminderTime.value).length };
+EOF
+
+DEADLINE=$(( $(date +%s) + TIMEOUT_SEC ))
+LAST_OUTPUT=""
+while [[ "$(date +%s)" -lt "$DEADLINE" ]]; do
+  if LAST_OUTPUT="$(node "$SCRIPT_DIR/obsidian-eval.mjs" "$PROBE" 2>&1)"; then
+    if [[ "$LAST_OUTPUT" == *'"ready": true'* ]]; then
+      echo "$LAST_OUTPUT"
+      exit 0
+    fi
+  fi
+  sleep 1
+done
+
+echo "error: not ready within ${TIMEOUT_SEC}s. Last response:" >&2
+echo "$LAST_OUTPUT" >&2
+exit 1


### PR DESCRIPTION
Four fixes to the `obsidian-e2e` skill, each one from something that actually went wrong while driving a live Obsidian for #356 / #357.

## 1. The test vault often has no window

Obsidian only reopens the vaults that were open when it was last quit, and the test vault frequently isn't one of them. Every script then failed with "found no page target," with nothing pointing at the cause. The fix was to open the vault by hand each time.

`obsidian-launch.sh` now waits ~8s for that vault's window and, if it doesn't appear, opens the vault through Obsidian's own URI scheme and waits for it. That step names a specific vault and makes Obsidian write its `workspace.json`, so it runs the same name/path/marker guards as the other scripts before opening anything. `--no-open-vault` turns it off.

## 2. A vault window has two title shapes, only one was matched

```
"<note> - <vault> - Obsidian <version>"   once a note is open
"<vault> - Obsidian <version>"            while none is
```

Only the first was matched. The second is what you see for the first seconds after a launch — exactly when a script polls for the window. The rule now lives in `scripts/lib/vault-window.mjs`, with a deliberate second copy in Python inside `obsidian-shot.sh`, which can't import it.

The added prefix form is anchored and immediately followed by `" - Obsidian"`, so it is stricter than the infix form, not looser.

## 3. The settings window made everything refuse to run

Obsidian 1.13 opens settings in its own window. Two pages then match the vault, and "exactly one match" aborted — which is why the settings tab could not be verified at all in #357.

```mermaid
flowchart TD
    A[pages whose title belongs to the vault] --> B{how many?}
    B -->|0| C[abort: is the vault open?]
    B -->|1| D[use it]
    B -->|2+| E[classify each with a read-only DOM probe<br/>run behind the existing vault + marker guard]
    E --> F[unusable: the probe could not confirm the vault]
    E --> G[main: has ribbon and root split]
    E --> H[other: e.g. a popped-out note]
    F --> I[never used]
    G --> J{--window main default}
    H --> J
    J -->|exactly 1| D
    J -->|otherwise| K[abort, listing each window and its kind]
```

The probe also answered a question worth recording: **the settings window's JS context has no `app` global**, so `app.vault.getName()` raises `ReferenceError` and the vault guard can never pass there. Nothing may be evaluated in that window, by this skill or anything else built on the same safety model. There is deliberately no `--window settings`.

Seeing the settings screen therefore means screenshotting it, so `obsidian-shot.sh` gains `--title-contains` to narrow among a vault's windows. Its CDP cross-check now requires the window list and the page list to agree on *how many* windows the vault has, instead of requiring that number to be one.

## 4. Readiness was fixed sleeps

`sleep 20` / `sleep 30` after each restart, chosen by guessing. New `obsidian-wait.sh` polls until the plugin exists and its initial vault scan has finished — 0.1s in practice, and it cannot return too early.

`--min-reminders N` also asserts that the fixtures parsed. This is the check that would have saved the most time: reminder syntax is only recognized when the matching format is enabled, and a checkout whose settings don't enable it parses every fixture to **zero reminders with no error anywhere**. It looks like the feature under test is broken.

## SKILL.md

Adds the two things that were missing when they were needed:

- **The plugin's `data.json` lives in the symlinked checkout, not the vault.** Swapping the symlink swaps the settings, and a fresh worktree starts with every setting at its default — which is exactly how the fixtures silently stopped parsing.
- **A persist → restart → assert recipe**, including forcing `data.save(true)` and reading `data.json` back before restarting, since that read is what separates "never persisted" from "persisted and discarded on load."

Also updated: the guard-stack description, the "what cannot be automated" list, and known limitations.

## Verified against a live Obsidian

Each change was exercised, not just written:

- Closed the test vault's window, ran `obsidian-launch.sh` → it reopened the vault and reported it.
- With the settings window open, default `--window main` evaluated normally; the settings window was recorded as `unusable` with its `ReferenceError` reason.
- `obsidian-shot.sh --title-contains` captured the settings window.
- `obsidian-wait.sh --min-reminders 3` returned `{ ready: true, reminders: 13, overdue: 0 }` in 0.1s.
- A vault with no marker file was rejected (exit 3) using a synthetic directory, not a real vault, and nothing was opened.
- `reminder-fire.sh` → the reminder fired and was observed through `systemNotifier.systemNotifications`.
